### PR TITLE
Remove sslverify=false from updater

### DIFF
--- a/mu-plugin/v-sys-plugin-updater-mu.php
+++ b/mu-plugin/v-sys-plugin-updater-mu.php
@@ -51,8 +51,8 @@ function vontmnt_plugin_updater_run_updates() {
 			VONTMENT_PLUGINS
 		);
 
-		// Use wp_remote_get instead of cURL.
-		$response      = wp_remote_get( $api_url, array( 'sslverify' => false ) );
+                // Use wp_remote_get instead of cURL.
+                $response      = wp_remote_get( $api_url );
 		$http_code     = wp_remote_retrieve_response_code( $response );
 		$response_body = wp_remote_retrieve_body( $response );
 

--- a/mu-plugin/v-sys-plugin-updater.php
+++ b/mu-plugin/v-sys-plugin-updater.php
@@ -50,7 +50,7 @@ function vontmnt_plugin_updater_run_updates()
         );
 
         // Use wp_remote_get instead of cURL.
-        $response      = wp_remote_get($api_url, array( 'sslverify' => false ));
+        $response      = wp_remote_get($api_url);
         $http_code     = wp_remote_retrieve_response_code($response);
         $response_body = wp_remote_retrieve_body($response);
 

--- a/mu-plugin/v-sys-theme-updater.php
+++ b/mu-plugin/v-sys-theme-updater.php
@@ -50,7 +50,7 @@ function vontmnt_theme_updater_run_updates()
             VONTMENT_THEMES
         );
 
-        $response      = wp_remote_get($api_url, array( 'sslverify' => false ));
+        $response      = wp_remote_get($api_url);
         $http_code     = wp_remote_retrieve_response_code($response);
         $response_body = wp_remote_retrieve_body($response);
 


### PR DESCRIPTION
## Summary
- remove `sslverify` overrides from `wp_remote_get`

## Testing
- `php -l mu-plugin/v-sys-plugin-updater.php`
- `php -l mu-plugin/v-sys-theme-updater.php`
- `php -l mu-plugin/v-sys-plugin-updater-mu.php`
- `curl -L -o /tmp/test-plugin.zip https://downloads.wordpress.org/plugin/akismet.latest-stable.zip`
- `unzip -l /tmp/test-plugin.zip | head`

------
https://chatgpt.com/codex/tasks/task_e_686860774ce4832a85777670ea6d4acd