### PR TITLE
Improve plugin/theme deletion security

### DIFF
--- a/update-api/classes/forms/PlFormHandler.php
+++ b/update-api/classes/forms/PlFormHandler.php
@@ -94,8 +94,12 @@ class PlFormHandler
     private function deletePlugin($plugin_name)
     {
         $plugin_name = Security::sanitizeInput($plugin_name);
+        $plugin_name = basename($plugin_name);
         $plugin_path = PLUGINS_DIR . '/' . $plugin_name;
-        if (file_exists($plugin_path)) {
+        if (
+            file_exists($plugin_path)
+            && dirname(realpath($plugin_path)) === realpath(PLUGINS_DIR)
+        ) {
             if (unlink($plugin_path)) {
                 echo '<script>'
                     . 'alert("Plugin deleted successfully!");'

--- a/update-api/classes/forms/ThFormHandler.php
+++ b/update-api/classes/forms/ThFormHandler.php
@@ -93,8 +93,12 @@ class ThFormHandler
     private function deleteTheme($theme_name)
     {
         $theme_name = Security::sanitizeInput($theme_name);
+        $theme_name = basename($theme_name);
         $theme_path = THEMES_DIR . '/' . $theme_name;
-        if (file_exists($theme_path)) {
+        if (
+            file_exists($theme_path)
+            && dirname(realpath($theme_path)) === realpath(THEMES_DIR)
+        ) {
             if (unlink($theme_path)) {
                 echo '<script>'
                     . 'alert("Theme deleted successfully!");'


### PR DESCRIPTION
## Summary
- sanitize user input and strip path components
- verify target file is inside allowed directory before deleting

## Testing
- `php -l update-api/classes/forms/PlFormHandler.php`
- `php -l update-api/classes/forms/ThFormHandler.php`
- `find update-api -name '*.php' -print | xargs -n 1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68686086ba44832aa6619dd01ed7a84c