### PR TITLE
Enforce typed signatures without strict mode

### DIFF
--- a/mu-plugin/v-sys-plugin-updater-mu.php
+++ b/mu-plugin/v-sys-plugin-updater-mu.php
@@ -21,7 +21,7 @@ add_action( 'wp', 'vontmnt_plugin_updater_schedule_updates' );
 /**
  * Schedule daily plugin update checks for multisite.
  */
-function vontmnt_plugin_updater_schedule_updates() {
+function vontmnt_plugin_updater_schedule_updates(): void {
 	if ( ! wp_next_scheduled( 'vontmnt_plugin_updater_check_updates' ) ) {
 		wp_schedule_event( time(), 'daily', 'vontmnt_plugin_updater_check_updates' );
 	}
@@ -32,7 +32,7 @@ add_action( 'vontmnt_plugin_updater_check_updates', 'vontmnt_plugin_updater_run_
 /**
  * Run plugin updates for all installed plugins on the main site.
  */
-function vontmnt_plugin_updater_run_updates() {
+function vontmnt_plugin_updater_run_updates(): void {
 	// Check if it's the main site.
 	if ( ! is_main_site() ) {
 		return;

--- a/mu-plugin/v-sys-plugin-updater.php
+++ b/mu-plugin/v-sys-plugin-updater.php
@@ -18,7 +18,7 @@ if (! defined('ABSPATH')) {
 /**
  * Schedule daily plugin update checks.
  */
-function vontmnt_plugin_updater_schedule_updates()
+function vontmnt_plugin_updater_schedule_updates(): void
 {
     if (! wp_next_scheduled('vontmnt_plugin_updater_check_updates')) {
         wp_schedule_event(time(), 'daily', 'vontmnt_plugin_updater_check_updates');
@@ -32,7 +32,7 @@ add_action('vontmnt_plugin_updater_check_updates', 'vontmnt_plugin_updater_run_u
 /**
  * Run plugin updates for all installed plugins.
  */
-function vontmnt_plugin_updater_run_updates()
+function vontmnt_plugin_updater_run_updates(): void
 {
     $plugins = get_plugins();
     foreach ($plugins as $plugin_path => $plugin) {

--- a/mu-plugin/v-sys-theme-updater.php
+++ b/mu-plugin/v-sys-theme-updater.php
@@ -19,7 +19,7 @@ if (! defined('ABSPATH')) {
 /**
  * Schedule daily theme update checks.
  */
-function vontmnt_theme_updater_schedule_updates()
+function vontmnt_theme_updater_schedule_updates(): void
 {
     if (! wp_next_scheduled('vontmnt_theme_updater_check_updates')) {
         wp_schedule_event(time(), 'daily', 'vontmnt_theme_updater_check_updates');
@@ -33,7 +33,7 @@ add_action('vontmnt_theme_updater_check_updates', 'vontmnt_theme_updater_run_upd
 /**
  * Run theme updates for all installed themes.
  */
-function vontmnt_theme_updater_run_updates()
+function vontmnt_theme_updater_run_updates(): void
 {
     $themes = wp_get_themes();
     foreach ($themes as $theme) {

--- a/update-api/classes/forms/HomeFormHandler.php
+++ b/update-api/classes/forms/HomeFormHandler.php
@@ -14,7 +14,7 @@ use UpdateApi\util\Security;
 
 class HomeFormHandler
 {
-    public function handleRequest()
+    public function handleRequest(): void
     {
         if (
             $_SERVER['REQUEST_METHOD'] === 'POST'
@@ -39,7 +39,7 @@ class HomeFormHandler
         }
     }
 
-    private function addEntry($domain, $key)
+    private function addEntry(?string $domain, ?string $key): void
     {
         $hosts_file = HOSTS_ACL . '/HOSTS';
         // Escape output for safety
@@ -51,7 +51,7 @@ class HomeFormHandler
         exit();
     }
 
-    private function updateEntry($line_number, $domain, $key)
+    private function updateEntry(?int $line_number, ?string $domain, ?string $key): void
     {
         $hosts_file = HOSTS_ACL . '/HOSTS';
         $entries = file($hosts_file, FILE_IGNORE_NEW_LINES);
@@ -64,7 +64,7 @@ class HomeFormHandler
         exit();
     }
 
-    private function deleteEntry($line_number, $domain_to_delete)
+    private function deleteEntry(?int $line_number, ?string $domain_to_delete): void
     {
         $hosts_file = HOSTS_ACL . '/HOSTS';
         $entries = file($hosts_file, FILE_IGNORE_NEW_LINES);

--- a/update-api/classes/forms/PlFormHandler.php
+++ b/update-api/classes/forms/PlFormHandler.php
@@ -14,7 +14,7 @@ use UpdateApi\util\Security;
 
 class PlFormHandler
 {
-    public function handleRequest()
+    public function handleRequest(): void
     {
         if (
             $_SERVER['REQUEST_METHOD'] === 'POST'
@@ -35,7 +35,7 @@ class PlFormHandler
         }
     }
 
-    private function uploadPluginFiles()
+    private function uploadPluginFiles(): void
     {
         $allowed_extensions = ['zip'];
         $total_files = count($_FILES['plugin_file']['name']);
@@ -91,7 +91,7 @@ class PlFormHandler
         }
     }
 
-    private function deletePlugin($plugin_name)
+    private function deletePlugin(?string $plugin_name): void
     {
         $plugin_name = Security::sanitizeInput($plugin_name);
         $plugin_name = basename($plugin_name);

--- a/update-api/classes/forms/ThFormHandler.php
+++ b/update-api/classes/forms/ThFormHandler.php
@@ -14,7 +14,7 @@ use UpdateApi\util\Security;
 
 class ThFormHandler
 {
-    public function handleRequest()
+    public function handleRequest(): void
     {
         if (
             $_SERVER['REQUEST_METHOD'] === 'POST'
@@ -34,7 +34,7 @@ class ThFormHandler
         }
     }
 
-    private function uploadThemeFiles()
+    private function uploadThemeFiles(): void
     {
         $allowed_extensions = ['zip'];
         $total_files = count($_FILES['theme_file']['name']);
@@ -90,7 +90,7 @@ class ThFormHandler
         }
     }
 
-    private function deleteTheme($theme_name)
+    private function deleteTheme(?string $theme_name): void
     {
         $theme_name = Security::sanitizeInput($theme_name);
         $theme_name = basename($theme_name);

--- a/update-api/classes/helpers/HomeHelper.php
+++ b/update-api/classes/helpers/HomeHelper.php
@@ -12,7 +12,7 @@ namespace UpdateApi\helpers;
 
 class HomeHelper
 {
-    public static function generateHostsTableRow($lineNumber, $domain, $key)
+    public static function generateHostsTableRow(int $lineNumber, string $domain, string $key): string
     {
         return '<tr>
             <form method="post" action="/">
@@ -38,7 +38,7 @@ class HomeHelper
      *
      * @return string
      */
-    public static function getHostsTableHtml()
+    public static function getHostsTableHtml(): string
     {
         $hostsFile = HOSTS_ACL . '/HOSTS';
         $entries = file($hostsFile, FILE_IGNORE_NEW_LINES);

--- a/update-api/classes/helpers/LogsHelper.php
+++ b/update-api/classes/helpers/LogsHelper.php
@@ -12,7 +12,7 @@ namespace UpdateApi\helpers;
 
 class LogsHelper
 {
-    public static function processLogFile($logFile)
+    public static function processLogFile(string $logFile): string
     {
         $log_file_path = LOG_DIR . "/$logFile";
         $output = '';

--- a/update-api/classes/helpers/PlHelper.php
+++ b/update-api/classes/helpers/PlHelper.php
@@ -12,7 +12,7 @@ namespace UpdateApi\helpers;
 
 class PlHelper
 {
-    public static function generatePluginTableRow($plugin, $pluginName)
+    public static function generatePluginTableRow(string $plugin, string $pluginName): string
     {
         return '<tr>
             <td>' . htmlspecialchars($pluginName, ENT_QUOTES, 'UTF-8') . '</td>
@@ -32,7 +32,7 @@ class PlHelper
      *
      * @return string
      */
-    public static function getPluginsTableHtml()
+    public static function getPluginsTableHtml(): string
     {
         $plugins = glob(PLUGINS_DIR . "/*.zip");
         $plugins = array_reverse($plugins);

--- a/update-api/classes/helpers/ThHelper.php
+++ b/update-api/classes/helpers/ThHelper.php
@@ -12,7 +12,7 @@ namespace UpdateApi\helpers;
 
 class ThHelper
 {
-    public static function generateThemeTableRow($theme, $theme_name)
+    public static function generateThemeTableRow(string $theme, string $theme_name): string
     {
         return '<tr>
              <td>' . htmlspecialchars($theme_name, ENT_QUOTES, 'UTF-8') . '</td>
@@ -32,7 +32,7 @@ class ThHelper
      *
      * @return string
      */
-    public static function getThemesTableHtml()
+    public static function getThemesTableHtml(): string
     {
         $themes = glob(THEMES_DIR . "/*.zip");
         $themes = array_reverse($themes);

--- a/update-api/classes/util/security.php
+++ b/update-api/classes/util/security.php
@@ -18,7 +18,7 @@ class Security
      * @param string $data
      * @return string
      */
-    public static function sanitizeInput($data)
+    public static function sanitizeInput(string $data): string
     {
         $data = trim(strip_tags($data));
         $data = htmlspecialchars($data, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
@@ -35,7 +35,7 @@ class Security
      * @param array $disallowedChars
      * @return bool
      */
-    public static function containsDisallowedChars($str, $disallowedChars)
+    public static function containsDisallowedChars(string $str, array $disallowedChars): bool
     {
         if (!is_array($disallowedChars)) {
             return false;
@@ -55,7 +55,7 @@ class Security
      * @param array $disallowedPatterns
      * @return bool
      */
-    public static function containsDisallowedPatterns($str, $disallowedPatterns)
+    public static function containsDisallowedPatterns(string $str, array $disallowedPatterns): bool
     {
         if (!is_array($disallowedPatterns)) {
             return false;
@@ -75,7 +75,7 @@ class Security
      * @param string $ip
      * @return void
      */
-    public static function updateFailedAttempts($ip)
+    public static function updateFailedAttempts(string $ip): void
     {
         $blacklist_file = BLACKLIST_DIR . "/BLACKLIST.json";
         $content = [];
@@ -123,7 +123,7 @@ class Security
      * @param string $ip
      * @return bool
      */
-    public static function isBlacklisted($ip)
+    public static function isBlacklisted(string $ip): bool
     {
         $blacklist_file = BLACKLIST_DIR . "/BLACKLIST.json";
         $blacklist = [];


### PR DESCRIPTION
## Summary
- remove `declare(strict_types=1);` from plugin and API files

## Testing
- `find update-api mu-plugin -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_686868f967f4832a9a3e4cd6051b18a0