### PR TITLE
Remove namespaces and adjust autoload

### DIFF
--- a/update-api/classes/forms/HomeFormHandler.php
+++ b/update-api/classes/forms/HomeFormHandler.php
@@ -1,4 +1,5 @@
 <?php
+// @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
 
 /*
  * Project: Update API
@@ -8,9 +9,7 @@
  * Description: WordPress Update API
  */
 
-namespace UpdateApi\forms;
 
-use UpdateApi\util\Security;
 
 class HomeFormHandler
 {

--- a/update-api/classes/forms/PlFormHandler.php
+++ b/update-api/classes/forms/PlFormHandler.php
@@ -1,4 +1,5 @@
 <?php
+// @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
 
 /*
  * Project: Update API
@@ -8,9 +9,7 @@
  * Description: WordPress Update API
  */
 
-namespace UpdateApi\forms;
 
-use UpdateApi\util\Security;
 
 class PlFormHandler
 {

--- a/update-api/classes/forms/ThFormHandler.php
+++ b/update-api/classes/forms/ThFormHandler.php
@@ -1,4 +1,5 @@
 <?php
+// @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
 
 /*
  * Project: Update API
@@ -8,9 +9,7 @@
  * Description: WordPress Update API
  */
 
-namespace UpdateApi\forms;
 
-use UpdateApi\util\Security;
 
 class ThFormHandler
 {

--- a/update-api/classes/helpers/HomeHelper.php
+++ b/update-api/classes/helpers/HomeHelper.php
@@ -1,4 +1,5 @@
 <?php
+// @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
 
 /*
  * Project: Update API
@@ -8,7 +9,6 @@
  * Description: WordPress Update API Helper for Home page
  */
 
-namespace UpdateApi\helpers;
 
 class HomeHelper
 {

--- a/update-api/classes/helpers/LogsHelper.php
+++ b/update-api/classes/helpers/LogsHelper.php
@@ -1,4 +1,5 @@
 <?php
+// @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
 
 /*
  * Project: Update API
@@ -8,7 +9,6 @@
  * Description: WordPress Update API Helper for logs display and processing
  */
 
-namespace UpdateApi\helpers;
 
 class LogsHelper
 {

--- a/update-api/classes/helpers/PlHelper.php
+++ b/update-api/classes/helpers/PlHelper.php
@@ -1,4 +1,5 @@
 <?php
+// @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
 
 /*
  * Project: Update API
@@ -8,7 +9,6 @@
  * Description: WordPress Update API Helper for plugin updates
  */
 
-namespace UpdateApi\helpers;
 
 class PlHelper
 {

--- a/update-api/classes/helpers/ThHelper.php
+++ b/update-api/classes/helpers/ThHelper.php
@@ -1,4 +1,5 @@
 <?php
+// @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
 
 /*
  * Project: Update API
@@ -8,7 +9,6 @@
  * Description: WordPress Update API Helper for theme updates
  */
 
-namespace UpdateApi\helpers;
 
 class ThHelper
 {

--- a/update-api/classes/util/security.php
+++ b/update-api/classes/util/security.php
@@ -1,4 +1,5 @@
 <?php
+// @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
 
 /*
  * Project: Update API
@@ -8,7 +9,6 @@
  * Description: Security utilities (moved from waf-lib.php)
  */
 
-namespace UpdateApi\util;
 
 class Security
 {

--- a/update-api/lib/auth-lib.php
+++ b/update-api/lib/auth-lib.php
@@ -9,7 +9,6 @@
 */
 
 
-use UpdateApi\util\Security;
 
 if (isset($_SESSION['logged_in']) && $_SESSION['logged_in'] === true) {
     if (isset($_POST["logout"])) {

--- a/update-api/lib/class-lib.php
+++ b/update-api/lib/class-lib.php
@@ -8,15 +8,22 @@
  * Description: WordPress Update API
  */
 
-// Autoload function to automatically include class files
+// Autoload function to include class files without namespaces
 spl_autoload_register(function ($class_name) {
-    $parts = explode('\\', $class_name);
-    // Remove the first part of the namespace (e.g., 'Vontainment')
-    array_shift($parts);
-    $file = dirname(__DIR__) . '/classes/' . implode('/', $parts) . '.php';
-    if (file_exists($file)) {
-        require_once $file;
-    } else {
-        error_log("Class file not found: " . $file);
+    $base = dirname(__DIR__) . '/classes/';
+    $dirs = ['forms', 'helpers', 'util'];
+    foreach ($dirs as $dir) {
+        $file = $base . $dir . '/' . $class_name . '.php';
+        if (file_exists($file)) {
+            require_once $file;
+            return;
+        }
+        // Fallback to lowercase file names
+        $file = $base . $dir . '/' . strtolower($class_name) . '.php';
+        if (file_exists($file)) {
+            require_once $file;
+            return;
+        }
     }
+    error_log('Class file not found: ' . $class_name);
 });

--- a/update-api/lib/load-lib.php
+++ b/update-api/lib/load-lib.php
@@ -8,7 +8,6 @@
  * Description: WordPress Update API
 */
 
-use UpdateApi\util\Security;
 
 $ip = $_SERVER['REMOTE_ADDR'];
 $requestUri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);

--- a/update-api/public/api.php
+++ b/update-api/public/api.php
@@ -10,7 +10,6 @@
 require_once '../config.php';
 require_once '../lib/class-lib.php';
 
-use UpdateApi\util\Security;
 
 $ip = $_SERVER['REMOTE_ADDR'];
 if (Security::isBlacklisted($ip) || $_SERVER['REQUEST_METHOD'] !== 'GET') {

--- a/update-api/views/home.php
+++ b/update-api/views/home.php
@@ -8,8 +8,6 @@
  * Description: WordPress Update API
 */
 
-use UpdateApi\forms\HomeFormHandler;
-use UpdateApi\helpers\HomeHelper;
 
 $handler = new HomeFormHandler();
 $handler->handleRequest();

--- a/update-api/views/logs.php
+++ b/update-api/views/logs.php
@@ -8,7 +8,6 @@
  * Description: WordPress Update API
 */
 
-use UpdateApi\helpers\LogsHelper;
 
 $ploutput = LogsHelper::processLogFile('plugin.log');
 $thoutput = LogsHelper::processLogFile('theme.log');

--- a/update-api/views/plupdate.php
+++ b/update-api/views/plupdate.php
@@ -8,8 +8,6 @@
  * Description: WordPress Update API
  */
 
-use UpdateApi\helpers\PlHelper;
-use UpdateApi\forms\PlFormHandler;
 
 $handler = new PlFormHandler();
 $handler->handleRequest();

--- a/update-api/views/thupdate.php
+++ b/update-api/views/thupdate.php
@@ -8,8 +8,6 @@
  * Description: WordPress Update API
  */
 
-use UpdateApi\helpers\ThHelper;
-use UpdateApi\forms\ThFormHandler;
 
 $handler = new ThFormHandler();
 $handler->handleRequest();


### PR DESCRIPTION
## Summary
- drop namespaces from PHP classes
- add a PHPCS disable comment
- adjust autoloader for new class locations
- remove namespace references in API views and libs

## Testing
- `php -l update-api/lib/class-lib.php`
- `php -l update-api/classes/forms/HomeFormHandler.php`
- `php -l update-api/classes/forms/PlFormHandler.php`
- `php -l update-api/classes/forms/ThFormHandler.php`
- `php -l update-api/classes/helpers/HomeHelper.php`
- `php -l update-api/classes/helpers/LogsHelper.php`
- `php -l update-api/classes/helpers/PlHelper.php`
- `php -l update-api/classes/helpers/ThHelper.php`
- `php -l update-api/classes/util/security.php`
- `php -l update-api/lib/auth-lib.php`
- `php -l update-api/lib/load-lib.php`
- `php -l update-api/public/api.php`
- `php -l update-api/views/home.php`
- `php -l update-api/views/plupdate.php`
- `php -l update-api/views/thupdate.php`
- `php -l update-api/views/logs.php`
- `php -l mu-plugin/v-sys-plugin-updater.php`
- `php -l mu-plugin/v-sys-plugin-updater-mu.php`
- `php -l mu-plugin/v-sys-theme-updater.php`

------
https://chatgpt.com/codex/tasks/task_e_68686ff179d0832a8332999c44f51aee