### PR TITLE
Add error handling and input validation

### DIFF
--- a/update-api/classes/forms/HomeFormHandler.php
+++ b/update-api/classes/forms/HomeFormHandler.php
@@ -20,9 +20,9 @@ class HomeFormHandler
             && isset($_POST['csrf_token'], $_SESSION['csrf_token'])
             && $_POST['csrf_token'] === $_SESSION['csrf_token']
         ) {
-            // Sanitize all POST inputs
-            $domain = isset($_POST['domain']) ? Security::sanitizeInput($_POST['domain']) : null;
-            $key = isset($_POST['key']) ? Security::sanitizeInput($_POST['key']) : null;
+            // Validate all POST inputs
+            $domain = isset($_POST['domain']) ? SecurityHandler::validateDomain($_POST['domain']) : null;
+            $key = isset($_POST['key']) ? SecurityHandler::validateKey($_POST['key']) : null;
             $id = isset($_POST['id']) ? filter_var($_POST['id'], FILTER_VALIDATE_INT) : null;
             if (isset($_POST['add_entry'])) {
                 $this->addEntry($domain, $key);

--- a/update-api/classes/forms/PlFormHandler.php
+++ b/update-api/classes/forms/PlFormHandler.php
@@ -20,11 +20,11 @@ class PlFormHandler
             && isset($_POST['csrf_token'], $_SESSION['csrf_token'])
             && $_POST['csrf_token'] === $_SESSION['csrf_token']
         ) {
-            // Sanitize POST and FILES inputs
+            // Validate POST and FILES inputs
             if (isset($_FILES['plugin_file'])) {
                 $this->uploadPluginFiles();
             } elseif (isset($_POST['delete_plugin'])) {
-                $plugin_name = isset($_POST['plugin_name']) ? Security::sanitizeInput($_POST['plugin_name']) : null;
+                $plugin_name = isset($_POST['plugin_name']) ? SecurityHandler::validateSlug($_POST['plugin_name']) : null;
                 $this->deletePlugin($plugin_name);
             } else {
                 die('Invalid form action.');
@@ -41,7 +41,7 @@ class PlFormHandler
 
         for ($i = 0; $i < $total_files; $i++) {
             $file_name = isset($_FILES['plugin_file']['name'][$i])
-                ? Security::sanitizeInput($_FILES['plugin_file']['name'][$i])
+                ? SecurityHandler::validateFilename($_FILES['plugin_file']['name'][$i])
                 : '';
             $file_tmp = isset($_FILES['plugin_file']['tmp_name'][$i])
                 ? $_FILES['plugin_file']['tmp_name'][$i]
@@ -92,8 +92,8 @@ class PlFormHandler
 
     private function deletePlugin(?string $plugin_name): void
     {
-        $plugin_name = Security::sanitizeInput($plugin_name);
-        $plugin_name = basename($plugin_name);
+        $plugin_name = SecurityHandler::validateFilename($plugin_name);
+        $plugin_name = basename((string) $plugin_name);
         $plugin_path = PLUGINS_DIR . '/' . $plugin_name;
         if (
             file_exists($plugin_path)

--- a/update-api/classes/forms/ThFormHandler.php
+++ b/update-api/classes/forms/ThFormHandler.php
@@ -23,7 +23,7 @@ class ThFormHandler
             if (isset($_FILES['theme_file'])) {
                 $this->uploadThemeFiles();
             } elseif (isset($_POST['delete_theme'])) {
-                $theme_name = isset($_POST['theme_name']) ? Security::sanitizeInput($_POST['theme_name']) : null;
+                $theme_name = isset($_POST['theme_name']) ? SecurityHandler::validateSlug($_POST['theme_name']) : null;
                 $this->deleteTheme($theme_name);
             } else {
                 die('Invalid form action.');
@@ -40,7 +40,7 @@ class ThFormHandler
 
         for ($i = 0; $i < $total_files; $i++) {
             $file_name = isset($_FILES['theme_file']['name'][$i])
-                ? Security::sanitizeInput($_FILES['theme_file']['name'][$i])
+                ? SecurityHandler::validateFilename($_FILES['theme_file']['name'][$i])
                 : '';
             $file_tmp = isset($_FILES['theme_file']['tmp_name'][$i])
                 ? $_FILES['theme_file']['tmp_name'][$i]
@@ -91,8 +91,8 @@ class ThFormHandler
 
     private function deleteTheme(?string $theme_name): void
     {
-        $theme_name = Security::sanitizeInput($theme_name);
-        $theme_name = basename($theme_name);
+        $theme_name = SecurityHandler::validateFilename($theme_name);
+        $theme_name = basename((string) $theme_name);
         $theme_path = THEMES_DIR . '/' . $theme_name;
         if (
             file_exists($theme_path)

--- a/update-api/classes/util/ErrorHandler.php
+++ b/update-api/classes/util/ErrorHandler.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * Class ErrorHandler
+ * Handles error and exception logging and display.
+ */
+class ErrorHandler // @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+{
+    /**
+     * ErrorHandler constructor.
+     * Registers error, exception, and shutdown handlers.
+     */
+    public function __construct()
+    {
+        self::register();
+    }
+
+    /**
+     * Registers error, exception, and shutdown handlers.
+     */
+    public static function register(): void
+    {
+        set_error_handler([self::class, 'handleError']);
+        set_exception_handler([self::class, 'handleException']);
+        register_shutdown_function([self::class, 'handleShutdown']);
+    }
+
+    /**
+     * Handles PHP errors by converting them to exceptions.
+     *
+     * @param int $errno The level of the error raised.
+     * @param string $errstr The error message.
+     * @param string $errfile The filename that the error was raised in.
+     * @param int $errline The line number the error was raised at.
+     * @return bool
+     * @throws ErrorException
+     */
+    public static function handleError(int $errno, string $errstr, string $errfile, int $errline): bool
+    {
+        if (!(error_reporting() & $errno)) {
+            return false;
+        }
+        throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
+    }
+
+    /**
+     * Handles uncaught exceptions.
+     *
+     * @param Throwable $exception The uncaught exception.
+     */
+    public static function handleException(Throwable $exception): void
+    {
+        $message = "Uncaught Exception: " . $exception->getMessage() .
+            " in " . $exception->getFile() .
+            " on line " . $exception->getLine();
+        self::logMessage($message, 'exception');
+        http_response_code(500);
+        echo "Something went wrong. Please try again later.";
+    }
+
+    /**
+     * Handles fatal errors on shutdown.
+     */
+    public static function handleShutdown(): void
+    {
+        $error = error_get_last();
+        if ($error && in_array($error['type'], [E_ERROR, E_CORE_ERROR, E_COMPILE_ERROR, E_PARSE])) {
+            $message = "Fatal Error: {$error['message']} in {$error['file']} on line {$error['line']}";
+            self::logMessage($message, 'fatal');
+            http_response_code(500);
+            echo "A critical error occurred.";
+        }
+    }
+
+    /**
+     * Logs error messages to a log file.
+     *
+     * @param string $message The error message to log.
+     * @param string $type The type of error (default is 'error').
+     */
+    public static function logMessage(string $message, string $type = 'error'): void
+    {
+        $logFile = __DIR__ . '/../php_app.log';
+        $timestamp = date("Y-m-d H:i:s");
+        $logMessage = "[$timestamp] [$type]: $message\n";
+        error_log($logMessage, 3, $logFile);
+    }
+}

--- a/update-api/classes/util/SecurityHandler.php
+++ b/update-api/classes/util/SecurityHandler.php
@@ -10,62 +10,60 @@
  */
 
 
-class Security
+class SecurityHandler
 {
     /**
-     * Sanitize and validate input data
-     *
-     * @param string $data
-     * @return string
+     * Validate a domain string
      */
-    public static function sanitizeInput(string $data): string
+    public static function validateDomain(string $domain): ?string
     {
-        $data = trim(strip_tags($data));
-        $data = htmlspecialchars($data, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
-        $data = str_replace(array("<?", "?>", "<%", "%>"), "", $data);
-        $data = str_replace(array("<script", "</script"), "", $data);
-        $data = str_replace(array("/bin/sh", "exec(", "system(", "passthru(", "shell_exec(", "phpinfo("), "", $data);
-        return $data;
+        $domain = strtolower(trim($domain));
+        return filter_var($domain, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) ? $domain : null;
     }
 
     /**
-     * Check if a string contains a disallowed character
-     *
-     * @param string $str
-     * @param array $disallowedChars
-     * @return bool
+     * Validate an API key or generic token
      */
-    public static function containsDisallowedChars(string $str, array $disallowedChars): bool
+    public static function validateKey(string $key): ?string
     {
-        if (!is_array($disallowedChars)) {
-            return false;
-        }
-        foreach ($disallowedChars as $char) {
-            if (strpos($str, $char) !== false) {
-                return true;
-            }
-        }
-        return false;
+        $key = trim($key);
+        return preg_match('/^[A-Za-z0-9_-]+$/', $key) ? $key : null;
     }
 
     /**
-     * Check if a string contains a disallowed pattern
-     *
-     * @param string $str
-     * @param array $disallowedPatterns
-     * @return bool
+     * Validate plugin or theme names and slugs
      */
-    public static function containsDisallowedPatterns(string $str, array $disallowedPatterns): bool
+    public static function validateSlug(string $slug): ?string
     {
-        if (!is_array($disallowedPatterns)) {
-            return false;
-        }
-        foreach ($disallowedPatterns as $pattern) {
-            if (strpos($str, $pattern) !== false) {
-                return true;
-            }
-        }
-        return false;
+        $slug = basename(trim($slug));
+        return preg_match('/^[A-Za-z0-9._-]+$/', $slug) ? $slug : null;
+    }
+
+    /**
+     * Validate a version number such as 1.0.0
+     */
+    public static function validateVersion(string $version): ?string
+    {
+        $version = trim($version);
+        return preg_match('/^\d+(?:\.\d+)*$/', $version) ? $version : null;
+    }
+
+    /**
+     * Validate usernames for the admin interface
+     */
+    public static function validateUsername(string $username): ?string
+    {
+        $username = trim($username);
+        return preg_match('/^[A-Za-z0-9._-]{3,30}$/', $username) ? $username : null;
+    }
+
+    /**
+     * Basic password validation
+     */
+    public static function validatePassword(string $password): ?string
+    {
+        $password = trim($password);
+        return strlen($password) >= 6 ? $password : null;
     }
 
     /**

--- a/update-api/lib/auth-lib.php
+++ b/update-api/lib/auth-lib.php
@@ -22,8 +22,8 @@ if (isset($_SESSION['logged_in']) && $_SESSION['logged_in'] === true) {
 }
 
 if (isset($_POST['username']) && isset($_POST['password'])) {
-    $username = Security::sanitizeInput($_POST['username']);
-    $password = Security::sanitizeInput($_POST['password']);
+    $username = SecurityHandler::validateUsername($_POST['username']);
+    $password = SecurityHandler::validatePassword($_POST['password']);
 
     // Perform your login authentication logic here
     if ($username === VALID_USERNAME && $password === VALID_PASSWORD) {
@@ -39,12 +39,12 @@ if (isset($_POST['username']) && isset($_POST['password'])) {
         // Failed login
         $ip = $_SERVER['REMOTE_ADDR'];
 
-        if (Security::isBlacklisted($ip)) {
+        if (SecurityHandler::isBlacklisted($ip)) {
             // Show the message that the user has been blacklisted
             $error_msg = "Your IP has been blacklisted due to multiple failed login attempts.";
         } else {
             // Update the number of failed login attempts and check if the IP should be blacklisted
-            Security::updateFailedAttempts($ip);
+            SecurityHandler::updateFailedAttempts($ip);
             $error_msg = "Invalid username or password.";
         }
     }

--- a/update-api/lib/load-lib.php
+++ b/update-api/lib/load-lib.php
@@ -24,7 +24,7 @@ $routes = [
           ];
 
 // Combined blacklist, login logic, redirection, and routing
-if (Security::isBlacklisted($ip)) {
+if (SecurityHandler::isBlacklisted($ip)) {
     http_response_code(403);
     echo "Your IP address has been blacklisted. If you believe this is an error, please contact us.";
     exit();

--- a/update-api/public/api.php
+++ b/update-api/public/api.php
@@ -12,7 +12,7 @@ require_once '../lib/class-lib.php';
 
 
 $ip = $_SERVER['REMOTE_ADDR'];
-if (Security::isBlacklisted($ip) || $_SERVER['REQUEST_METHOD'] !== 'GET') {
+if (SecurityHandler::isBlacklisted($ip) || $_SERVER['REQUEST_METHOD'] !== 'GET') {
     http_response_code(403);
     exit();
 } else {
@@ -30,9 +30,13 @@ if (Security::isBlacklisted($ip) || $_SERVER['REQUEST_METHOD'] !== 'GET') {
             http_response_code(400);
             exit();
         }
-        $values[] = Security::sanitizeInput($_GET[$p]);
+        $values[] = $_GET[$p];
     }
     list($type, $domain, $key, $slug, $version) = $values;
+    $domain = SecurityHandler::validateDomain($domain);
+    $key = SecurityHandler::validateKey($key);
+    $slug = SecurityHandler::validateSlug($slug);
+    $version = SecurityHandler::validateVersion($version);
 
     if ($type === 'theme') {
         $dir = THEMES_DIR;


### PR DESCRIPTION
## Summary
- introduce `ErrorHandler` for centralized PHP error management
- rename `security.php` to `SecurityHandler.php`
- validate domains, keys, filenames, slugs, versions, usernames and passwords
- update form handlers and API to use new security checks

## Testing
- `find update-api -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68687d0758d8832a877cc607a13ea8de