### PR TITLE
Add toast notifications and secure sessions

### DIFF
--- a/update-api/classes/forms/HomeFormHandler.php
+++ b/update-api/classes/forms/HomeFormHandler.php
@@ -46,6 +46,7 @@ class HomeFormHandler
         $safe_key = htmlspecialchars($key, ENT_QUOTES, 'UTF-8');
         $new_entry = $safe_domain . ' ' . $safe_key;
         file_put_contents($hosts_file, $new_entry . "\n", FILE_APPEND | LOCK_EX);
+        $_SESSION['messages'][] = 'Entry added successfully.';
         header('Location: /home');
         exit();
     }
@@ -59,6 +60,7 @@ class HomeFormHandler
         $safe_key = htmlspecialchars($key, ENT_QUOTES, 'UTF-8');
         $entries[$line_number] = $safe_domain . ' ' . $safe_key;
         file_put_contents($hosts_file, implode("\n", $entries) . "\n");
+        $_SESSION['messages'][] = 'Entry updated successfully.';
         header('Location: /home');
         exit();
     }
@@ -87,6 +89,7 @@ class HomeFormHandler
                 file_put_contents($log_file_path, implode("\n", $filtered_entries) . "\n");
             }
         }
+        $_SESSION['messages'][] = 'Entry deleted successfully.';
         header('Location: /home');
         exit();
     }

--- a/update-api/classes/forms/PlFormHandler.php
+++ b/update-api/classes/forms/PlFormHandler.php
@@ -62,31 +62,19 @@ class PlFormHandler
             }
 
             if ($file_error !== UPLOAD_ERR_OK || !in_array($file_extension, $allowed_extensions)) {
-                echo '<script>'
-                    . 'alert("Error uploading: '
-                    . htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8')
-                    . '. Only .zip files are allowed.");'
-                    . 'window.location.href = "/plupdate";'
-                    . '</script>';
-                exit;
+                $_SESSION['messages'][] = 'Error uploading: ' . htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8') . '. Only .zip files are allowed.';
+                header('Location: /plupdate');
+                exit();
             }
 
             $plugin_path = PLUGINS_DIR . '/' . $file_name;
             if (move_uploaded_file($file_tmp, $plugin_path)) {
-                echo '<script>'
-                    . 'alert("'
-                    . htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8')
-                    . ' uploaded successfully.");'
-                    . 'window.location.href = "/plupdate";'
-                    . '</script>';
+                $_SESSION['messages'][] = htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8') . ' uploaded successfully.';
             } else {
-                echo '<script>'
-                    . 'alert("Error uploading: '
-                    . htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8')
-                    . '");'
-                    . 'window.location.href = "/plupdate";'
-                    . '</script>';
+                $_SESSION['messages'][] = 'Error uploading: ' . htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8');
             }
+            header('Location: /plupdate');
+            exit();
         }
     }
 
@@ -100,16 +88,12 @@ class PlFormHandler
             && dirname(realpath($plugin_path)) === realpath(PLUGINS_DIR)
         ) {
             if (unlink($plugin_path)) {
-                echo '<script>'
-                    . 'alert("Plugin deleted successfully!");'
-                    . 'window.location.href = "/plupdate";'
-                    . '</script>';
+                $_SESSION['messages'][] = 'Plugin deleted successfully!';
             } else {
-                echo '<script>'
-                    . 'alert("Failed to delete plugin file. Please try again.");'
-                    . 'window.location.href = "/plupdate";'
-                    . '</script>';
+                $_SESSION['messages'][] = 'Failed to delete plugin file. Please try again.';
             }
+            header('Location: /plupdate');
+            exit();
         }
     }
 }

--- a/update-api/classes/forms/ThFormHandler.php
+++ b/update-api/classes/forms/ThFormHandler.php
@@ -61,31 +61,19 @@ class ThFormHandler
             }
 
             if ($file_error !== UPLOAD_ERR_OK || !in_array($file_extension, $allowed_extensions)) {
-                echo '<script>'
-                    . 'alert("Error uploading: '
-                    . htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8')
-                    . '. Only .zip files are allowed.");'
-                    . 'window.location.href = "/thupdate";'
-                    . '</script>';
-                exit;
+                $_SESSION['messages'][] = 'Error uploading: ' . htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8') . '. Only .zip files are allowed.';
+                header('Location: /thupdate');
+                exit();
             }
 
             $theme_path = THEMES_DIR . '/' . $file_name;
             if (move_uploaded_file($file_tmp, $theme_path)) {
-                echo '<script>'
-                    . 'alert("'
-                    . htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8')
-                    . ' uploaded successfully.");'
-                    . 'window.location.href = "/thupdate";'
-                    . '</script>';
+                $_SESSION['messages'][] = htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8') . ' uploaded successfully.';
             } else {
-                echo '<script>'
-                    . 'alert("Error uploading: '
-                    . htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8')
-                    . '");'
-                    . 'window.location.href = "/thupdate";'
-                    . '</script>';
+                $_SESSION['messages'][] = 'Error uploading: ' . htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8');
             }
+            header('Location: /thupdate');
+            exit();
         }
     }
 
@@ -99,16 +87,12 @@ class ThFormHandler
             && dirname(realpath($theme_path)) === realpath(THEMES_DIR)
         ) {
             if (unlink($theme_path)) {
-                echo '<script>'
-                    . 'alert("Theme deleted successfully!");'
-                    . 'window.location.href = "/thupdate";'
-                    . '</script>';
+                $_SESSION['messages'][] = 'Theme deleted successfully!';
             } else {
-                echo '<script>'
-                    . 'alert("Failed to delete theme file. Please try again.");'
-                    . 'window.location.href = "/thupdate";'
-                    . '</script>';
+                $_SESSION['messages'][] = 'Failed to delete theme file. Please try again.';
             }
+            header('Location: /thupdate');
+            exit();
         }
     }
 }

--- a/update-api/classes/util/ErrorHandler.php
+++ b/update-api/classes/util/ErrorHandler.php
@@ -85,4 +85,19 @@ class ErrorHandler // @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamesp
         $logMessage = "[$timestamp] [$type]: $message\n";
         error_log($logMessage, 3, $logFile);
     }
+
+    /**
+     * Display and clear session messages.
+     *
+     * @return void
+     */
+    public static function displayAndClearMessages(): void
+    {
+        if (isset($_SESSION['messages']) && count($_SESSION['messages']) > 0) {
+            foreach ($_SESSION['messages'] as $message) {
+                echo '<script>showToast(' . json_encode($message) . ');</script>';
+            }
+            unset($_SESSION['messages']);
+        }
+    }
 }

--- a/update-api/public/assets/css/styles.css
+++ b/update-api/public/assets/css/styles.css
@@ -318,3 +318,66 @@ th {
 .success-message {
   color: #66cc33;
 }
+
+/* ================================================
+   TOAST STYLES
+================================================ */
+
+.toast {
+  position: fixed;
+  bottom: -80px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 9999;
+  transition: bottom 4s ease-in-out;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.5);
+  border: 2px solid #66cc33;
+  border-radius: 8px;
+  background-color: #fff;
+  padding: 16px;
+  width: 300px;
+  min-height: 60px;
+  color: #333;
+  text-align: center;
+}
+
+.toast.show {
+  bottom: 80px;
+}
+
+@-webkit-keyframes fadein {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fadein {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@-webkit-keyframes fadeout {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes fadeout {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+

--- a/update-api/public/assets/js/header-scripts.js
+++ b/update-api/public/assets/js/header-scripts.js
@@ -1,0 +1,19 @@
+/**
+ * Displays a toast message.
+ * @param {string} message - The message to display.
+ */
+function showToast(message) {
+    const toast = document.createElement('div');
+    toast.className = 'toast';
+    toast.textContent = message;
+    document.body.appendChild(toast);
+    setTimeout(() => {
+        toast.classList.add('show');
+    }, 10);
+    setTimeout(() => {
+        toast.classList.remove('show');
+        setTimeout(() => {
+            document.body.removeChild(toast);
+        }, 500);
+    }, 3000);
+}

--- a/update-api/public/index.php
+++ b/update-api/public/index.php
@@ -7,7 +7,15 @@
  * Description: WordPress Update API
 */
 
+// Set secure session cookie parameters before starting the session
+$secureFlag = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off');
+session_set_cookie_params([
+    'httponly' => true,
+    'secure' => $secureFlag,
+    'samesite' => 'Lax'
+]);
 session_start();
+session_regenerate_id(true); // Regenerate session ID to prevent session fixation attacks
 
 require_once '../config.php';
 require_once '../lib/class-lib.php';
@@ -78,6 +86,7 @@ require_once '../lib/load-lib.php';
         </p>
     </footer>
     <script src="/assets/js/footer-scripts.js"></script>
+    <?php echo ErrorHandler::displayAndClearMessages(); ?>
 </body>
 
 </html>

--- a/update-api/public/login.php
+++ b/update-api/public/login.php
@@ -7,6 +7,13 @@
  * Description: WordPress Update API
 */
 
+// Set secure session cookie parameters before starting the session
+$secureFlag = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off');
+session_set_cookie_params([
+    'httponly' => true,
+    'secure' => $secureFlag,
+    'samesite' => 'Lax'
+]);
 session_start();
 require_once '../config.php';
 require_once '../lib/class-lib.php';
@@ -35,10 +42,11 @@ require_once '../lib/auth-lib.php';
             <input type="password" name="password"><br><br>
             <input type="submit" value="Log In">
         </form>
-        <?php if (isset($error_msg)) : ?>
-            <div id="error-msg"><?php echo $error_msg; ?></div>
-        <?php endif; ?>
+    <?php if (isset($error_msg)) : ?>
+        <div id="error-msg"><?php echo $error_msg; ?></div>
+    <?php endif; ?>
     </div>
+    <?php echo ErrorHandler::displayAndClearMessages(); ?>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- implement `showToast` helper in `header-scripts.js`
- add session toast display in `ErrorHandler`
- style toast messages in CSS
- secure session cookies and regenerate ID in index
- update login page with secure cookie params
- surface messages after operations
- record status messages for host, plugin, and theme actions

## Testing
- `php -l update-api/public/index.php`
- `php -l update-api/public/login.php`
- `php -l update-api/classes/util/ErrorHandler.php`
- `php -l update-api/classes/forms/PlFormHandler.php`
- `php -l update-api/classes/forms/ThFormHandler.php`
- `php -l update-api/classes/forms/HomeFormHandler.php`

------
https://chatgpt.com/codex/tasks/task_e_686881f82670832a95a49e2bfa429381