### PR TITLE
Fix autoload and add filename validation

### DIFF
--- a/update-api/classes/SecurityHandler.php
+++ b/update-api/classes/SecurityHandler.php
@@ -5,7 +5,7 @@
  * Project: Update API
  * Author: Vontainment
  * URL: https://vontainment.com
- * File: security.php
+ * File: SecurityHandler.php
  * Description: Security utilities (moved from waf-lib.php)
  */
 
@@ -37,6 +37,15 @@ class SecurityHandler
     {
         $slug = basename(trim($slug));
         return preg_match('/^[A-Za-z0-9._-]+$/', $slug) ? $slug : null;
+    }
+
+    /**
+     * Validate uploaded file names
+     */
+    public static function validateFilename(string $filename): ?string
+    {
+        $filename = basename(trim($filename));
+        return preg_match('/^[A-Za-z0-9._-]+$/', $filename) ? $filename : null;
     }
 
     /**

--- a/update-api/lib/class-lib.php
+++ b/update-api/lib/class-lib.php
@@ -4,22 +4,19 @@
  * Project: Update API
  * Author: Vontainment
  * URL: https://vontainment.com
- * File: autoload.php
+ * File: class-lib.php
  * Description: WordPress Update API
  */
 
 // Autoload function to include class files without namespaces
 spl_autoload_register(function ($class_name) {
     $base = dirname(__DIR__) . '/classes/';
-    $file = $base . $class_name . '.php';
-    if (file_exists($file)) {
-        require_once $file;
-        return;
-    }
-    $file = $base . strtolower($class_name) . '.php';
-    if (file_exists($file)) {
-        require_once $file;
-        return;
+    $target = strtolower($class_name);
+    foreach (glob($base . '*.php') as $file) {
+        if (strtolower(basename($file, '.php')) === $target) {
+            require_once $file;
+            return;
+        }
     }
     error_log('Class file not found: ' . $class_name);
 });


### PR DESCRIPTION
## Summary
- use case-insensitive autoloading logic in `class-lib.php`
- add missing `validateFilename()` helper to `SecurityHandler`
- update file headers accordingly

## Testing
- `php -l update-api/lib/class-lib.php`
- `php -l update-api/classes/SecurityHandler.php`
- `find update-api -name '*.php' | xargs -I {} php -l {}`
- `php -l mu-plugin/v-sys-plugin-updater.php`
- `php -l mu-plugin/v-sys-plugin-updater-mu.php`
- `php -l mu-plugin/v-sys-theme-updater.php`

------
https://chatgpt.com/codex/tasks/task_e_68688a87c3f4832a8c54867852113778