### PR TITLE
Add error logging and session messages

### DIFF
--- a/update-api/classes/PlHelper.php
+++ b/update-api/classes/PlHelper.php
@@ -25,10 +25,18 @@ class PlHelper
                 $plugin_name = isset($_POST['plugin_name']) ? SecurityHandler::validateSlug($_POST['plugin_name']) : null;
                 self::deletePlugin($plugin_name);
             } else {
-                die('Invalid form action.');
+                $error = 'Invalid form action.';
+                ErrorHandler::logMessage($error);
+                $_SESSION['messages'][] = $error;
+                header('Location: /plupdate');
+                exit();
             }
         } elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
-            die('Invalid CSRF token.');
+            $error = 'Invalid CSRF token.';
+            ErrorHandler::logMessage($error);
+            $_SESSION['messages'][] = $error;
+            header('Location: /plupdate');
+            exit();
         }
     }
 
@@ -60,7 +68,9 @@ class PlHelper
             }
 
             if ($file_error !== UPLOAD_ERR_OK || !in_array($file_extension, $allowed_extensions)) {
-                $_SESSION['messages'][] = 'Error uploading: ' . htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8') . '. Only .zip files are allowed.';
+                $error = 'Error uploading: ' . htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8') . '. Only .zip files are allowed.';
+                ErrorHandler::logMessage($error);
+                $_SESSION['messages'][] = $error;
                 header('Location: /plupdate');
                 exit();
             }
@@ -69,7 +79,9 @@ class PlHelper
             if (move_uploaded_file($file_tmp, $plugin_path)) {
                 $_SESSION['messages'][] = htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8') . ' uploaded successfully.';
             } else {
-                $_SESSION['messages'][] = 'Error uploading: ' . htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8');
+                $error = 'Error uploading: ' . htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8');
+                ErrorHandler::logMessage($error);
+                $_SESSION['messages'][] = $error;
             }
             header('Location: /plupdate');
             exit();
@@ -88,7 +100,9 @@ class PlHelper
             if (unlink($plugin_path)) {
                 $_SESSION['messages'][] = 'Plugin deleted successfully!';
             } else {
-                $_SESSION['messages'][] = 'Failed to delete plugin file. Please try again.';
+                $error = 'Failed to delete plugin file. Please try again.';
+                ErrorHandler::logMessage($error);
+                $_SESSION['messages'][] = $error;
             }
             header('Location: /plupdate');
             exit();

--- a/update-api/classes/ThHelper.php
+++ b/update-api/classes/ThHelper.php
@@ -25,10 +25,18 @@ class ThHelper
                 $theme_name = isset($_POST['theme_name']) ? SecurityHandler::validateSlug($_POST['theme_name']) : null;
                 self::deleteTheme($theme_name);
             } else {
-                die('Invalid form action.');
+                $error = 'Invalid form action.';
+                ErrorHandler::logMessage($error);
+                $_SESSION['messages'][] = $error;
+                header('Location: /thupdate');
+                exit();
             }
         } elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
-            die('Invalid CSRF token.');
+            $error = 'Invalid CSRF token.';
+            ErrorHandler::logMessage($error);
+            $_SESSION['messages'][] = $error;
+            header('Location: /thupdate');
+            exit();
         }
     }
 
@@ -60,7 +68,9 @@ class ThHelper
             }
 
             if ($file_error !== UPLOAD_ERR_OK || !in_array($file_extension, $allowed_extensions)) {
-                $_SESSION['messages'][] = 'Error uploading: ' . htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8') . '. Only .zip files are allowed.';
+                $error = 'Error uploading: ' . htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8') . '. Only .zip files are allowed.';
+                ErrorHandler::logMessage($error);
+                $_SESSION['messages'][] = $error;
                 header('Location: /thupdate');
                 exit();
             }
@@ -69,7 +79,9 @@ class ThHelper
             if (move_uploaded_file($file_tmp, $theme_path)) {
                 $_SESSION['messages'][] = htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8') . ' uploaded successfully.';
             } else {
-                $_SESSION['messages'][] = 'Error uploading: ' . htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8');
+                $error = 'Error uploading: ' . htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8');
+                ErrorHandler::logMessage($error);
+                $_SESSION['messages'][] = $error;
             }
             header('Location: /thupdate');
             exit();
@@ -88,7 +100,9 @@ class ThHelper
             if (unlink($theme_path)) {
                 $_SESSION['messages'][] = 'Theme deleted successfully!';
             } else {
-                $_SESSION['messages'][] = 'Failed to delete theme file. Please try again.';
+                $error = 'Failed to delete theme file. Please try again.';
+                ErrorHandler::logMessage($error);
+                $_SESSION['messages'][] = $error;
             }
             header('Location: /thupdate');
             exit();

--- a/update-api/lib/auth-lib.php
+++ b/update-api/lib/auth-lib.php
@@ -41,11 +41,15 @@ if (isset($_POST['username']) && isset($_POST['password'])) {
 
         if (SecurityHandler::isBlacklisted($ip)) {
             // Notify user if IP has been blacklisted
-            $_SESSION['messages'][] = 'Your IP has been blacklisted due to multiple failed login attempts.';
+            $error = 'Your IP has been blacklisted due to multiple failed login attempts.';
+            ErrorHandler::logMessage($error);
+            $_SESSION['messages'][] = $error;
         } else {
             // Update the number of failed login attempts and check if the IP should be blacklisted
             SecurityHandler::updateFailedAttempts($ip);
-            $_SESSION['messages'][] = 'Invalid username or password.';
+            $error = 'Invalid username or password.';
+            ErrorHandler::logMessage($error);
+            $_SESSION['messages'][] = $error;
         }
     }
 }

--- a/update-api/lib/class-lib.php
+++ b/update-api/lib/class-lib.php
@@ -18,5 +18,5 @@ spl_autoload_register(function ($class_name) {
             return;
         }
     }
-    error_log('Class file not found: ' . $class_name);
+    ErrorHandler::logMessage('Class file not found: ' . $class_name);
 });

--- a/update-api/lib/load-lib.php
+++ b/update-api/lib/load-lib.php
@@ -26,7 +26,10 @@ $routes = [
 // Combined blacklist, login logic, redirection, and routing
 if (SecurityHandler::isBlacklisted($ip)) {
     http_response_code(403);
-    echo "Your IP address has been blacklisted. If you believe this is an error, please contact us.";
+    $error = 'Your IP address has been blacklisted. If you believe this is an error, please contact us.';
+    ErrorHandler::logMessage($error);
+    $_SESSION['messages'][] = $error;
+    echo $error;
     exit();
 } elseif ((!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true) && $requestUri !== '/login') {
     header('Location: /login');
@@ -43,6 +46,9 @@ if (SecurityHandler::isBlacklisted($ip)) {
     }
 } else {
     http_response_code(404);
-    echo "Page not found or access denied.";
+    $error = 'Page not found or access denied.';
+    ErrorHandler::logMessage($error);
+    $_SESSION['messages'][] = $error;
+    echo $error;
     exit();
 }

--- a/update-api/public/api.php
+++ b/update-api/public/api.php
@@ -14,6 +14,7 @@ require_once '../lib/class-lib.php';
 $ip = $_SERVER['REMOTE_ADDR'];
 if (SecurityHandler::isBlacklisted($ip) || $_SERVER['REQUEST_METHOD'] !== 'GET') {
     http_response_code(403);
+    ErrorHandler::logMessage('Forbidden or invalid request from ' . $ip);
     exit();
 } else {
     // Sanitize, extract, and set required GET parameters, error if any missing or invalid
@@ -28,6 +29,7 @@ if (SecurityHandler::isBlacklisted($ip) || $_SERVER['REQUEST_METHOD'] !== 'GET')
     foreach ($params as $p) {
         if (!isset($_GET[$p]) || $_GET[$p] === '' || ($p === 'type' && !in_array($_GET[$p], ['plugin', 'theme']))) {
             http_response_code(400);
+            ErrorHandler::logMessage('Bad request missing parameter: ' . $p);
             exit();
         }
         $values[] = $_GET[$p];
@@ -70,6 +72,7 @@ if (SecurityHandler::isBlacklisted($ip) || $_SERVER['REQUEST_METHOD'] !== 'GET')
                                     readfile($file_path);
                                     $log_message = $domain . ' ' . date('Y-m-d,h:i:sa') . ' Successful';
                                     file_put_contents($log, $log_message . PHP_EOL, LOCK_EX | FILE_APPEND);
+                                    ErrorHandler::logMessage($log_message, 'info');
                                     exit();
                                 }
                             }
@@ -79,6 +82,7 @@ if (SecurityHandler::isBlacklisted($ip) || $_SERVER['REQUEST_METHOD'] !== 'GET')
                     http_response_code(204);
                     $log_message = $domain . ' ' . date('Y-m-d,h:i:sa') . ' Successful';
                     file_put_contents($log, $log_message . PHP_EOL, LOCK_EX | FILE_APPEND);
+                    ErrorHandler::logMessage($log_message, 'info');
                     exit();
                 }
             }
@@ -88,5 +92,6 @@ if (SecurityHandler::isBlacklisted($ip) || $_SERVER['REQUEST_METHOD'] !== 'GET')
     http_response_code(403);
     $log_message = $domain . ' ' . date('Y-m-d,h:i:sa') . ' Failed';
     file_put_contents($log, $log_message . PHP_EOL, LOCK_EX | FILE_APPEND);
+    ErrorHandler::logMessage($log_message);
     exit();
 }


### PR DESCRIPTION
## Summary
- log autoload failures via `ErrorHandler::logMessage`
- log errors and show messages for invalid form actions or CSRF issues
- capture plugin and theme upload errors
- record login failures and IP blacklist notices
- log forbidden requests and bad parameters in the update API

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68689fb20fd0832a8c62f25776b75aa5