### PR TITLE
Fix login security and multi-file uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,6 @@ The v-wordpress-plugin-updater project is designed to streamline the management 
 
 ## 🎗 License
 
-This project is protected under the [MIT License](https://github.com/djav1985/v-chatgpt-editor/blob/main/LICENSE) License.
+This project is licensed under the [GNU General Public License v3](LICENSE).
 
 ---

--- a/update-api/classes/PlHelper.php
+++ b/update-api/classes/PlHelper.php
@@ -71,8 +71,7 @@ class PlHelper
                 $error = 'Error uploading: ' . htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8') . '. Only .zip files are allowed.';
                 ErrorHandler::logMessage($error);
                 $_SESSION['messages'][] = $error;
-                header('Location: /plupdate');
-                exit();
+                continue;
             }
 
             $plugin_path = PLUGINS_DIR . '/' . $file_name;
@@ -83,9 +82,10 @@ class PlHelper
                 ErrorHandler::logMessage($error);
                 $_SESSION['messages'][] = $error;
             }
-            header('Location: /plupdate');
-            exit();
         }
+
+        header('Location: /plupdate');
+        exit();
     }
 
     private static function deletePlugin(?string $plugin_name): void

--- a/update-api/classes/ThHelper.php
+++ b/update-api/classes/ThHelper.php
@@ -71,8 +71,7 @@ class ThHelper
                 $error = 'Error uploading: ' . htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8') . '. Only .zip files are allowed.';
                 ErrorHandler::logMessage($error);
                 $_SESSION['messages'][] = $error;
-                header('Location: /thupdate');
-                exit();
+                continue;
             }
 
             $theme_path = THEMES_DIR . '/' . $file_name;
@@ -83,9 +82,10 @@ class ThHelper
                 ErrorHandler::logMessage($error);
                 $_SESSION['messages'][] = $error;
             }
-            header('Location: /thupdate');
-            exit();
         }
+
+        header('Location: /thupdate');
+        exit();
     }
 
     private static function deleteTheme(?string $theme_name): void

--- a/update-api/lib/load-lib.php
+++ b/update-api/lib/load-lib.php
@@ -19,9 +19,19 @@ $routes = [
            '/'         => 'home.php',
            '/plupdate' => 'plupdate.php',
            '/thupdate' => 'thupdate.php',
-           '/logs'     => 'logs.php',
+          '/logs'     => 'logs.php',
     // Add more routes here as needed
           ];
+
+// Verify that the User-Agent matches the one used during login
+if (isset($_SESSION['logged_in']) && $_SESSION['logged_in'] === true) {
+    if (!isset($_SESSION['user_agent']) || $_SESSION['user_agent'] !== $_SERVER['HTTP_USER_AGENT']) {
+        session_unset();
+        session_destroy();
+        header('Location: /login');
+        exit();
+    }
+}
 
 // Combined blacklist, login logic, redirection, and routing
 if (SecurityHandler::isBlacklisted($ip)) {

--- a/update-api/public/index.php
+++ b/update-api/public/index.php
@@ -37,8 +37,6 @@ require_once '../lib/load-lib.php';
     <script src="/assets/js/header-scripts.js"></script>
     <link rel="stylesheet" href="/assets/css/styles.css">
     <link rel="stylesheet" href="/assets/css/mobile.css">
-
-    <title>Dashboard</title>
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
- enforce User-Agent checks on every request
- fix plugin/theme upload loops so multiple files process
- remove duplicate title tag from admin template
- clarify GPLv3 license in README

## Testing
- `php -l update-api/classes/PlHelper.php`
- `php -l update-api/classes/ThHelper.php`
- `php -l update-api/lib/load-lib.php`
- `php -l update-api/public/index.php`


------
https://chatgpt.com/codex/tasks/task_e_6868a65f20c4832a878aaf25094d6092