### PR TITLE
Add early return for non-POST requests

### DIFF
--- a/update-api/classes/HomeHelper.php
+++ b/update-api/classes/HomeHelper.php
@@ -15,6 +15,9 @@ class HomeHelper
 {
     public static function handleRequest(): void
     {
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            return;
+        }
         if (
             $_SERVER['REQUEST_METHOD'] === 'POST' &&
             isset($_POST['csrf_token'], $_SESSION['csrf_token']) &&

--- a/update-api/classes/PlHelper.php
+++ b/update-api/classes/PlHelper.php
@@ -15,6 +15,9 @@ class PlHelper
 {
     public static function handleRequest(): void
     {
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            return;
+        }
         if (
             $_SERVER['REQUEST_METHOD'] === 'POST' &&
             isset($_POST['csrf_token'], $_SESSION['csrf_token']) &&

--- a/update-api/classes/ThHelper.php
+++ b/update-api/classes/ThHelper.php
@@ -15,6 +15,9 @@ class ThHelper
 {
     public static function handleRequest(): void
     {
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            return;
+        }
         if (
             $_SERVER['REQUEST_METHOD'] === 'POST' &&
             isset($_POST['csrf_token'], $_SESSION['csrf_token']) &&


### PR DESCRIPTION
## Summary
- exit early in helpers if the request method is not POST

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686901355058832aa1c7415678b653c6