### PR TITLE
Fix upgrader filter removal

### DIFF
--- a/mu-plugin/v-sys-plugin-updater-mu.php
+++ b/mu-plugin/v-sys-plugin-updater-mu.php
@@ -71,16 +71,14 @@ function vontmnt_plugin_updater_run_updates(): void {
 
                        require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
                        $upgrader = new Plugin_Upgrader();
-                       add_filter(
-                               'upgrader_package_options',
-                               function ( $options ) use ( $plugin_zip_file ) {
+                       $callback = function ( $options ) use ( $plugin_zip_file ) {
                                        $options['package']           = $plugin_zip_file;
                                        $options['clear_destination'] = true;
                                        return $options;
-                               }
-                       );
+                               };
+                       add_filter( 'upgrader_package_options', $callback );
                        $upgrader->install( $plugin_zip_file );
-                       remove_all_filters( 'upgrader_package_options' );
+                       remove_filter( 'upgrader_package_options', $callback );
 
                        // Delete the plugin zip file using wp_delete_file.
                        wp_delete_file( $plugin_zip_file );

--- a/mu-plugin/v-sys-plugin-updater.php
+++ b/mu-plugin/v-sys-plugin-updater.php
@@ -68,16 +68,14 @@ function vontmnt_plugin_updater_run_updates(): void
 
             require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
             $upgrader = new Plugin_Upgrader();
-            add_filter(
-                'upgrader_package_options',
-                function ($options) use ($plugin_zip_file) {
-                    $options['package']           = $plugin_zip_file;
-                    $options['clear_destination'] = true;
-                    return $options;
-                }
-            );
+            $callback = function ($options) use ($plugin_zip_file) {
+                $options['package']           = $plugin_zip_file;
+                $options['clear_destination'] = true;
+                return $options;
+            };
+            add_filter('upgrader_package_options', $callback);
             $upgrader->install($plugin_zip_file);
-            remove_all_filters('upgrader_package_options');
+            remove_filter('upgrader_package_options', $callback);
 
             // Delete the plugin zip file using wp_delete_file.
             wp_delete_file($plugin_zip_file);

--- a/mu-plugin/v-sys-theme-updater.php
+++ b/mu-plugin/v-sys-theme-updater.php
@@ -68,16 +68,14 @@ function vontmnt_theme_updater_run_updates(): void
 
             require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
             $upgrader = new Theme_Upgrader();
-            add_filter(
-                'upgrader_package_options',
-                function ($options) use ($theme_zip_file) {
-                    $options['package']           = $theme_zip_file;
-                    $options['clear_destination'] = true;
-                    return $options;
-                }
-            );
+            $callback = function ($options) use ($theme_zip_file) {
+                $options['package']           = $theme_zip_file;
+                $options['clear_destination'] = true;
+                return $options;
+            };
+            add_filter('upgrader_package_options', $callback);
             $upgrader->install($theme_zip_file);
-            remove_all_filters('upgrader_package_options');
+            remove_filter('upgrader_package_options', $callback);
 
             // Delete the theme zip file using wp_delete_file.
             wp_delete_file($theme_zip_file);


### PR DESCRIPTION
## Summary
- assign anonymous filter callbacks to variables
- remove only the added callback instead of all filters

## Testing
- `php -l mu-plugin/v-sys-plugin-updater.php`
- `php -l mu-plugin/v-sys-plugin-updater-mu.php`
- `php -l mu-plugin/v-sys-theme-updater.php`


------
https://chatgpt.com/codex/tasks/task_e_686901574c0c832a977abbb38d48f913