### PR TITLE
Add validation for API parameters

### DIFF
--- a/update-api/public/api.php
+++ b/update-api/public/api.php
@@ -40,6 +40,25 @@ if (UtilityHandler::isBlacklisted($ip) || $_SERVER['REQUEST_METHOD'] !== 'GET') 
     $slug = UtilityHandler::validateSlug($slug);
     $version = UtilityHandler::validateVersion($version);
 
+    $invalid = [];
+    if ($domain === null) {
+        $invalid[] = 'domain';
+    }
+    if ($key === null) {
+        $invalid[] = 'key';
+    }
+    if ($slug === null) {
+        $invalid[] = 'slug';
+    }
+    if ($version === null) {
+        $invalid[] = 'version';
+    }
+    if (!empty($invalid)) {
+        http_response_code(400);
+        ErrorHandler::logMessage('Bad request invalid parameter: ' . implode(', ', $invalid));
+        exit();
+    }
+
     if ($type === 'theme') {
         $dir = THEMES_DIR;
         $log = LOG_DIR . '/theme.log';


### PR DESCRIPTION
## Summary
- ensure validated domain, key, slug, and version are not null in the Update API

## Testing
- `php -l update-api/public/api.php`


------
https://chatgpt.com/codex/tasks/task_e_686908f376f0832a9bc03095b1aa97ad