### PR TITLE
Fix hosts path configuration

### DIFF
--- a/update-api/config.php
+++ b/update-api/config.php
@@ -6,7 +6,7 @@ define('VALID_PASSWORD', 'admin');
 define('SESSION_TIMEOUT_LIMIT', 1800);
 
 define('BASE_DIR', dirname($_SERVER['DOCUMENT_ROOT']));
-define('HOSTS_ACL', BASE_DIR . '/');
+define('HOSTS_ACL', BASE_DIR);
 define('PLUGINS_DIR', BASE_DIR . '/storage/plugins');
 define('THEMES_DIR', BASE_DIR . '/storage/themes');
 define('BLACKLIST_DIR', BASE_DIR . '/storage');

--- a/update-api/public/api.php
+++ b/update-api/public/api.php
@@ -51,7 +51,7 @@ if (UtilityHandler::isBlacklisted($ip) || $_SERVER['REQUEST_METHOD'] !== 'GET') 
     }
 
 // Validate domain and key with if/else only, no boolean flag
-    $host_file = @fopen(HOSTS_ACL . 'HOSTS', 'r');
+    $host_file = @fopen(HOSTS_ACL . '/HOSTS', 'r');
     if ($host_file) {
         while (($line = fgets($host_file)) !== false) {
             $line = trim($line);


### PR DESCRIPTION
## Summary
- remove trailing slash from HOSTS_ACL
- fix HOSTS file path in API

## Testing
- `php -l update-api/config.php`
- `php -l update-api/public/api.php`
- `php -l update-api/classes/HomeHelper.php`


------
https://chatgpt.com/codex/tasks/task_e_6869091af9f0832a8d6db3cf05115b35