### PR TITLE
Fix log parsing edge case

### DIFF
--- a/update-api/classes/LogsHelper.php
+++ b/update-api/classes/LogsHelper.php
@@ -21,7 +21,7 @@ class LogsHelper
             $log_array = file($log_file_path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
             $log_by_domain = [];
             foreach ($log_array as $entry) {
-                list($domain, $date, $status) = explode(' ', $entry);
+                list($domain, $date, $status) = explode(' ', $entry, 3);
                 $log_by_domain[$domain] = [
 
                                            'date'   => $date,


### PR DESCRIPTION
## Summary
- specify a limit when splitting log lines so any extra spaces don't corrupt parsing

## Testing
- `php -l update-api/classes/LogsHelper.php`
- `find update-api/classes -name '*.php' -print0 | xargs -0 -n 1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_686909240034832ab74e01e9f3147601