### PR TITLE
Remove unused variables from upload controllers

### DIFF
--- a/update-api/app/Controllers/PluginsController.php
+++ b/update-api/app/Controllers/PluginsController.php
@@ -69,9 +69,6 @@ class PluginsController // @phpcs:disable PSR1.Classes.ClassDeclaration.MissingN
             $file_tmp = isset($_FILES['plugin_file']['tmp_name'][$i])
             ? $_FILES['plugin_file']['tmp_name'][$i]
             : '';
-            $file_size = isset($_FILES['plugin_file']['size'][$i])
-            ? filter_var($_FILES['plugin_file']['size'][$i], FILTER_VALIDATE_INT)
-            : 0;
             $file_error = isset($_FILES['plugin_file']['error'][$i])
             ? filter_var($_FILES['plugin_file']['error'][$i], FILTER_VALIDATE_INT)
             : UPLOAD_ERR_NO_FILE;

--- a/update-api/app/Controllers/ThemesController.php
+++ b/update-api/app/Controllers/ThemesController.php
@@ -67,9 +67,6 @@ class ThemesController // @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNa
             $file_tmp = isset($_FILES['theme_file']['tmp_name'][$i])
                 ? $_FILES['theme_file']['tmp_name'][$i]
                 : '';
-            $file_size = isset($_FILES['theme_file']['size'][$i])
-                ? filter_var($_FILES['theme_file']['size'][$i], FILTER_VALIDATE_INT)
-                : 0;
             $file_error = isset($_FILES['theme_file']['error'][$i])
                 ? filter_var($_FILES['theme_file']['error'][$i], FILTER_VALIDATE_INT)
                 : UPLOAD_ERR_NO_FILE;


### PR DESCRIPTION
## Summary
- clean up unused `$file_size` variable assignments in upload handlers

## Testing
- `composer validate --no-check-all --strict`
- `php -l update-api/app/Controllers/PluginsController.php`
- `php -l update-api/app/Controllers/ThemesController.php`


------
https://chatgpt.com/codex/tasks/task_e_686b4fbf443c832a83eb71dfe1b057c9