### PR TITLE
Add ErrorHandler imports for controller logging

### DIFF
--- a/update-api/app/Controllers/HomeController.php
+++ b/update-api/app/Controllers/HomeController.php
@@ -15,6 +15,7 @@
 namespace App\Controllers;
 
 use App\Core\UtilityHandler;
+use App\Core\ErrorHandler;
 
 class HomeController // @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
 {

--- a/update-api/app/Controllers/LogsController.php
+++ b/update-api/app/Controllers/LogsController.php
@@ -14,6 +14,7 @@
 namespace App\Controllers;
 
 use App\Core\UtilityHandler;
+use App\Core\ErrorHandler;
 
 class LogsController // @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
 {

--- a/update-api/app/Controllers/PluginsController.php
+++ b/update-api/app/Controllers/PluginsController.php
@@ -14,6 +14,7 @@
 namespace App\Controllers;
 
 use App\Core\UtilityHandler;
+use App\Core\ErrorHandler;
 
 class PluginsController // @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
 {

--- a/update-api/app/Controllers/ThemesController.php
+++ b/update-api/app/Controllers/ThemesController.php
@@ -14,6 +14,7 @@
 namespace App\Controllers;
 
 use App\Core\UtilityHandler;
+use App\Core\ErrorHandler;
 
 class ThemesController // @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
 {


### PR DESCRIPTION
## Summary
- add missing ErrorHandler import in HomeController
- add missing ErrorHandler import in PluginsController
- add missing ErrorHandler import in ThemesController
- add missing ErrorHandler import in LogsController

## Testing
- `php -l update-api/app/Controllers/HomeController.php`
- `php -l update-api/app/Controllers/PluginsController.php`
- `php -l update-api/app/Controllers/ThemesController.php`
- `php -l update-api/app/Controllers/LogsController.php`


------
https://chatgpt.com/codex/tasks/task_e_686b4ffb3354832a95d4d894a0733c54