### PR TITLE
Add CSRF validation to deletion actions

### DIFF
--- a/update-api/app/Controllers/HomeController.php
+++ b/update-api/app/Controllers/HomeController.php
@@ -115,6 +115,17 @@ class HomeController // @phpcs:disable PSR1.Classes.ClassDeclaration.MissingName
      */
     private static function deleteEntry(?int $line_number, ?string $domain_to_delete): void
     {
+        if (
+            !isset($_POST['csrf_token'], $_SESSION['csrf_token']) ||
+            !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])
+        ) {
+            $error = 'Invalid CSRF token.';
+            ErrorHandler::logMessage($error);
+            $_SESSION['messages'][] = $error;
+            header('Location: /home');
+            exit();
+        }
+
         $hosts_file = HOSTS_ACL . '/HOSTS';
         $entries = file($hosts_file, FILE_IGNORE_NEW_LINES);
         unset($entries[$line_number]);
@@ -162,6 +173,8 @@ class HomeController // @phpcs:disable PSR1.Classes.ClassDeclaration.MissingName
         return '<tr>
             <form method="post" action="/home">
                 <input type="hidden" name="id" value="' . htmlspecialchars($lineNumber, ENT_QUOTES, 'UTF-8') . '">
+                <input type="hidden" name="csrf_token" value="' .
+                    htmlspecialchars($_SESSION['csrf_token'] ?? '', ENT_QUOTES, 'UTF-8') . '">
                 <td><input class="hosts-domain" type="text" name="domain" value="' .
                 htmlspecialchars($domain, ENT_QUOTES, 'UTF-8') .
             '"></td>

--- a/update-api/app/Controllers/PluginsController.php
+++ b/update-api/app/Controllers/PluginsController.php
@@ -118,6 +118,17 @@ class PluginsController // @phpcs:disable PSR1.Classes.ClassDeclaration.MissingN
      */
     private static function deletePlugin(?string $plugin_name): void
     {
+        if (
+            !isset($_POST['csrf_token'], $_SESSION['csrf_token']) ||
+            !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])
+        ) {
+            $error = 'Invalid CSRF token.';
+            ErrorHandler::logMessage($error);
+            $_SESSION['messages'][] = $error;
+            header('Location: /plupdate');
+            exit();
+        }
+
         $plugin_name = UtilityHandler::validateFilename($plugin_name);
         $plugin_name = basename((string) $plugin_name);
         $plugin_path = PLUGINS_DIR . '/' . $plugin_name;
@@ -153,6 +164,8 @@ class PluginsController // @phpcs:disable PSR1.Classes.ClassDeclaration.MissingN
                     <input type="hidden" name="plugin_name" value="' .
                     htmlspecialchars($pluginName, ENT_QUOTES, 'UTF-8') .
                 '">
+                    <input type="hidden" name="csrf_token" value="' .
+                    htmlspecialchars($_SESSION['csrf_token'] ?? '', ENT_QUOTES, 'UTF-8') . '">
                     <button class="pl-submit" type="submit" name="delete_plugin">Delete</button>
                 </form>
             </td>

--- a/update-api/app/Controllers/ThemesController.php
+++ b/update-api/app/Controllers/ThemesController.php
@@ -116,6 +116,17 @@ class ThemesController // @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNa
      */
     private static function deleteTheme(?string $theme_name): void
     {
+        if (
+            !isset($_POST['csrf_token'], $_SESSION['csrf_token']) ||
+            !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])
+        ) {
+            $error = 'Invalid CSRF token.';
+            ErrorHandler::logMessage($error);
+            $_SESSION['messages'][] = $error;
+            header('Location: /thupdate');
+            exit();
+        }
+
         $theme_name = UtilityHandler::validateFilename($theme_name);
         $theme_name = basename((string) $theme_name);
         $theme_path = THEMES_DIR . '/' . $theme_name;
@@ -152,6 +163,8 @@ class ThemesController // @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNa
                      <input type="hidden" name="theme_name" value="' .
                          htmlspecialchars($theme, ENT_QUOTES, 'UTF-8') .
                      '">
+                     <input type="hidden" name="csrf_token" value="' .
+                         htmlspecialchars($_SESSION['csrf_token'] ?? '', ENT_QUOTES, 'UTF-8') . '">
                      <input class="th-submit" type="submit" name="delete_theme" value="Delete">
                  </form>
              </td>


### PR DESCRIPTION
## Summary
- verify CSRF token inside host, plugin and theme deletion actions
- include hidden CSRF token fields in deletion forms

## Testing
- `php -l update-api/app/Controllers/PluginsController.php`
- `php -l update-api/app/Controllers/ThemesController.php`
- `php -l update-api/app/Controllers/HomeController.php`


------
https://chatgpt.com/codex/tasks/task_e_686b502471b8832ab064d15e54a57bf1