### PR TITLE
Add LogsController request handler

### DIFF
--- a/update-api/app/Controllers/LogsController.php
+++ b/update-api/app/Controllers/LogsController.php
@@ -18,6 +18,23 @@ use App\Core\UtilityHandler;
 class LogsController // @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
 {
     /**
+     * Handles displaying the logs page.
+     *
+     * Gathers plugin and theme log output using {@see processLogFile()} and
+     * loads the corresponding view.
+     *
+     * @return void
+     */
+    public static function handleRequest(): void
+    {
+        $pluginLog = self::processLogFile('plugin.log');
+        $themeLog  = self::processLogFile('theme.log');
+
+        // Expose variables to the view scope
+        require __DIR__ . '/../Views/logs.php';
+    }
+
+    /**
      * Processes a log file and generates HTML output.
      *
      * Reads the log file, groups entries by domain, and generates HTML for each entry.

--- a/update-api/app/Lib/Loader.php
+++ b/update-api/app/Lib/Loader.php
@@ -45,7 +45,6 @@ if ($ip && UtilityHandler::isBlacklisted($ip)) {
                      'home',
                      'plupdate',
                      'thupdate',
-                     'logs',
                     ];
 
     // Sanitize and validate the requested page

--- a/update-api/app/Views/logs.php
+++ b/update-api/app/Views/logs.php
@@ -11,16 +11,13 @@
  * Description: WordPress Update API
  */
 
-use App\Controllers\LogsController;
 require_once __DIR__ . '/layouts/header.php';
-$ploutput = LogsController::processLogFile('plugin.log');
-$thoutput = LogsController::processLogFile('theme.log');
 
 ?>
 <div class="content-box">
     <h2>Plugin Log</h2>
-    <?php echo $ploutput; ?>
+    <?php echo $pluginLog ?? ''; ?>
     <h2>Theme Log</h2>
-    <?php echo $thoutput; ?>
+    <?php echo $themeLog ?? ''; ?>
 </div>
 <?php require_once __DIR__ . '/layouts/footer.php'; ?>


### PR DESCRIPTION
## Summary
- implement `LogsController::handleRequest()` to prepare log data and load the view
- adjust loader not to directly serve the logs view
- update `logs.php` to use variables provided by the controller

## Testing
- `php -l update-api/app/Controllers/LogsController.php`
- `php -l update-api/app/Views/logs.php`
- `php -l update-api/app/Lib/Loader.php`


------
https://chatgpt.com/codex/tasks/task_e_686b503028dc832aa3f19d8c68d3d5e4