### PR TITLE
Fix plugin/theme updater and API scanning

### DIFF
--- a/mu-plugin/v-sys-plugin-updater-mu.php
+++ b/mu-plugin/v-sys-plugin-updater-mu.php
@@ -55,7 +55,10 @@ function vontmnt_plugin_updater_run_updates(): void
     if (! is_main_site()) {
         return;
     }
-       $plugins = get_plugins();
+    if (! function_exists('get_plugins')) {
+        require_once ABSPATH . 'wp-admin/includes/plugin.php';
+    }
+    $plugins = get_plugins();
     foreach ($plugins as $plugin_path => $plugin) {
             $plugin_slug       = dirname($plugin_path);
             $installed_version = $plugin['Version'];

--- a/mu-plugin/v-sys-plugin-updater.php
+++ b/mu-plugin/v-sys-plugin-updater.php
@@ -46,6 +46,9 @@ add_action('vontmnt_plugin_updater_check_updates', 'vontmnt_plugin_updater_run_u
  * Run plugin updates for all installed plugins. */
 function vontmnt_plugin_updater_run_updates(): void
 {
+    if (! function_exists('get_plugins')) {
+        require_once ABSPATH . 'wp-admin/includes/plugin.php';
+    }
     $plugins = get_plugins();
     foreach ($plugins as $plugin_path => $plugin) {
         $plugin_slug       = dirname($plugin_path);

--- a/mu-plugin/v-sys-theme-updater.php
+++ b/mu-plugin/v-sys-theme-updater.php
@@ -47,6 +47,9 @@ add_action('vontmnt_theme_updater_check_updates', 'vontmnt_theme_updater_run_upd
  * Run theme updates for all installed themes. */
 function vontmnt_theme_updater_run_updates(): void
 {
+    if (! function_exists('wp_get_themes')) {
+        require_once ABSPATH . 'wp-includes/theme.php';
+    }
     $themes = wp_get_themes();
     foreach ($themes as $theme) {
         $theme_slug        = $theme->get_stylesheet();

--- a/update-api/app/Controllers/HomeController.php
+++ b/update-api/app/Controllers/HomeController.php
@@ -202,7 +202,7 @@ class HomeController // @phpcs:disable PSR1.Classes.ClassDeclaration.MissingName
     public static function getHostsTableHtml(): string
     {
         $hostsFile = HOSTS_ACL . '/HOSTS';
-        $entries = file($hostsFile, FILE_IGNORE_NEW_LINES);
+        $entries = file_exists($hostsFile) ? file($hostsFile, FILE_IGNORE_NEW_LINES) : [];
         $hostsTableHtml = '';
         if (count($entries) > 0) {
             $halfCount = ceil(count($entries) / 2);

--- a/update-api/public/api.php
+++ b/update-api/public/api.php
@@ -84,11 +84,14 @@ if (UtilityHandler::isBlacklisted($ip) || $_SERVER['REQUEST_METHOD'] !== 'GET') 
                     fclose($host_file);
                     // Find and serve update if available
                     foreach (scandir($dir) as $filename) {
+                        if ($filename === '.' || $filename === '..') {
+                            continue;
+                        }
                         if (strpos($filename, $slug) === 0) {
                             $filename_parts = explode('_', $filename);
                             if (isset($filename_parts[1]) && version_compare($filename_parts[1], $version, '>')) {
                                 $file_path = $dir . '/' . $filename;
-                                if (file_exists($file_path)) {
+                                if (is_file($file_path)) {
                                     header('Content-Type: application/octet-stream');
                                     header('Content-Disposition: attachment; filename="' . basename($file_path) . '"');
                                     header('Content-Length: ' . filesize($file_path));


### PR DESCRIPTION
## Summary
- include missing WordPress functions before calling them
- skip `.` and `..` entries when scanning update directories
- avoid warnings if HOSTS file doesn't exist

## Testing
- `php -l mu-plugin/v-sys-plugin-updater.php`
- `php -l mu-plugin/v-sys-plugin-updater-mu.php`
- `php -l mu-plugin/v-sys-theme-updater.php`
- `php -l update-api/public/api.php`
- `php -l update-api/app/Controllers/HomeController.php`


------
https://chatgpt.com/codex/tasks/task_e_686b51fc439c832aaf40e3f0513efb4b