### PR TITLE
Fix package tags in plugin headers

### DIFF
--- a/mu-plugin/v-sys-plugin-updater-mu.php
+++ b/mu-plugin/v-sys-plugin-updater-mu.php
@@ -1,10 +1,13 @@
 <?php
-
-/** 
- * @package UpdateAPI
- * @author  Vontainment <services@vontainment.com>
- * @license https://opensource.org/licenses/MIT MIT License
- * @link    https://vontainment.com
+/**
+ * Project: UpdateAPI
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
+ *
+ * File: v-sys-plugin-updater-mu.php
+ * Description: WordPress Update API
  *
  * Plugin Name: WP Plugin Updater MU
  * Plugin URI: https://vontainment.com
@@ -12,8 +15,8 @@
  * Version: 1.0.0
  * Author: Vontainment
  * Author URI: https://vontainment.com
- *
- * @package VontainmentPluginUpdaterMU */
+ * @package VontainmentPluginUpdaterMU
+*/
 
 if (! defined('ABSPATH')) {
     exit;

--- a/mu-plugin/v-sys-plugin-updater.php
+++ b/mu-plugin/v-sys-plugin-updater.php
@@ -1,10 +1,13 @@
 <?php
-
-/** 
- * @package UpdateAPI
- * @author  Vontainment <services@vontainment.com>
- * @license https://opensource.org/licenses/MIT MIT License
- * @link    https://vontainment.com
+/**
+ * Project: UpdateAPI
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
+ *
+ * File: v-sys-plugin-updater.php
+ * Description: WordPress Update API
  *
  * Plugin Name: WP Plugin Updater
  * Plugin URI: https://vontainment.com
@@ -12,8 +15,8 @@
  * Version: 1.2.0
  * Author: Vontainment
  * Author URI: https://vontainment.com
- *
- * @package VontainmentPluginUpdater */
+ * @package VontainmentPluginUpdater
+*/
 
 if (! defined('ABSPATH')) {
     exit;

--- a/mu-plugin/v-sys-theme-updater.php
+++ b/mu-plugin/v-sys-theme-updater.php
@@ -1,10 +1,13 @@
 <?php
-
-/** 
- * @package UpdateAPI
- * @author  Vontainment <services@vontainment.com>
- * @license https://opensource.org/licenses/MIT MIT License
- * @link    https://vontainment.com
+/**
+ * Project: UpdateAPI
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
+ *
+ * File: v-sys-theme-updater.php
+ * Description: WordPress Update API
  *
  * Theme Name: WP Theme Updater
  * Theme URI: https://vontainment.com
@@ -12,8 +15,8 @@
  * Version: 1.2.0
  * Author: Vontainment
  * Author URI: https://vontainment.com
- *
- * @package VontainmentThemeUpdater */
+ * @package VontainmentThemeUpdater
+*/
 
 if (! defined('ABSPATH')) {
     exit;

--- a/update-api/app/Controllers/AuthController.php
+++ b/update-api/app/Controllers/AuthController.php
@@ -1,11 +1,10 @@
 <?php
-
 /**
- * @package UpdateAPI
- * @author  Vontainment <services@vontainment.com>
- * @license https://opensource.org/licenses/MIT MIT License
- * @link    https://vontainment.com
- * @version 3.0.0
+ * Project: UpdateAPI
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
  *
  * File: AuthController.php
  * Description: WordPress Update API

--- a/update-api/app/Controllers/HomeController.php
+++ b/update-api/app/Controllers/HomeController.php
@@ -1,11 +1,10 @@
 <?php
-
 /**
- * @package UpdateAPI
- * @author  Vontainment <services@vontainment.com>
- * @license https://opensource.org/licenses/MIT MIT License
- * @link    https://vontainment.com
- * @version 3.0.0
+ * Project: UpdateAPI
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
  *
  * File: HomeController.php
  * Description: WordPress Update API

--- a/update-api/app/Controllers/LogsController.php
+++ b/update-api/app/Controllers/LogsController.php
@@ -1,11 +1,10 @@
 <?php
-
 /**
- * @package UpdateAPI
- * @author  Vontainment <services@vontainment.com>
- * @license https://opensource.org/licenses/MIT MIT License
- * @link    https://vontainment.com
- * @version 3.0.0
+ * Project: UpdateAPI
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
  *
  * File: LogsController.php
  * Description: WordPress Update API

--- a/update-api/app/Controllers/PluginsController.php
+++ b/update-api/app/Controllers/PluginsController.php
@@ -1,11 +1,10 @@
 <?php
-
 /**
- * @package UpdateAPI
- * @author  Vontainment <services@vontainment.com>
- * @license https://opensource.org/licenses/MIT MIT License
- * @link    https://vontainment.com
- * @version 3.0.0
+ * Project: UpdateAPI
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
  *
  * File: PluginsController.php
  * Description: WordPress Update API

--- a/update-api/app/Controllers/ThemesController.php
+++ b/update-api/app/Controllers/ThemesController.php
@@ -1,11 +1,10 @@
 <?php
-
 /**
- * @package UpdateAPI
- * @author  Vontainment <services@vontainment.com>
- * @license https://opensource.org/licenses/MIT MIT License
- * @link    https://vontainment.com
- * @version 3.0.0
+ * Project: UpdateAPI
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
  *
  * File: ThemesController.php
  * Description: WordPress Update API

--- a/update-api/app/Core/AuthMiddleware.php
+++ b/update-api/app/Core/AuthMiddleware.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Project: UpdateAPI
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
+ *
+ * File: AuthMiddleware.php
+ * Description: WordPress Update API
+ */
 
 namespace App\Core;
 

--- a/update-api/app/Core/Controller.php
+++ b/update-api/app/Core/Controller.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Project: UpdateAPI
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
+ *
+ * File: Controller.php
+ * Description: WordPress Update API
+ */
 
 namespace App\Core;
 

--- a/update-api/app/Core/ErrorHandler.php
+++ b/update-api/app/Core/ErrorHandler.php
@@ -1,14 +1,14 @@
 <?php
-
 /**
- * @package UpdateAPI
- * @author  Vontainment <services@vontainment.com>
- * @license https://opensource.org/licenses/MIT MIT License
- * @link    https://vontainment.com
+ * Project: UpdateAPI
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
  *
  * File: ErrorHandler.php
  * Description: WordPress Update API
-*/
+ */
 
 namespace App\Core;
 

--- a/update-api/app/Core/Router.php
+++ b/update-api/app/Core/Router.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Project: UpdateAPI
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
+ *
+ * File: Router.php
+ * Description: WordPress Update API
+ */
 
 namespace App\Core;
 

--- a/update-api/app/Core/UtilityHandler.php
+++ b/update-api/app/Core/UtilityHandler.php
@@ -1,11 +1,10 @@
 <?php
-
 /**
- * @package UpdateAPI
- * @author  Vontainment <services@vontainment.com>
- * @license https://opensource.org/licenses/MIT MIT License
- * @link    https://vontainment.com
- * @version 3.0.0
+ * Project: UpdateAPI
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
  *
  * File: UtilityHandler.php
  * Description: WordPress Update API

--- a/update-api/app/Models/HostsModel.php
+++ b/update-api/app/Models/HostsModel.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Project: UpdateAPI
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
+ *
+ * File: HostsModel.php
+ * Description: WordPress Update API
+ */
 
 namespace App\Models;
 

--- a/update-api/app/Models/LogModel.php
+++ b/update-api/app/Models/LogModel.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Project: UpdateAPI
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
+ *
+ * File: LogModel.php
+ * Description: WordPress Update API
+ */
 
 namespace App\Models;
 

--- a/update-api/app/Models/PluginModel.php
+++ b/update-api/app/Models/PluginModel.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Project: UpdateAPI
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
+ *
+ * File: PluginModel.php
+ * Description: WordPress Update API
+ */
 
 namespace App\Models;
 

--- a/update-api/app/Models/ThemeModel.php
+++ b/update-api/app/Models/ThemeModel.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Project: UpdateAPI
  * Author:  Vontainment <services@vontainment.com>

--- a/update-api/app/Views/home.php
+++ b/update-api/app/Views/home.php
@@ -1,11 +1,10 @@
 <?php
-
 /**
- * @package UpdateAPI
- * @author  Vontainment <services@vontainment.com>
- * @license https://opensource.org/licenses/MIT MIT License
- * @link    https://vontainment.com
- * @version 3.0.0
+ * Project: UpdateAPI
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
  *
  * File: home.php
  * Description: WordPress Update API

--- a/update-api/app/Views/layouts/footer.php
+++ b/update-api/app/Views/layouts/footer.php
@@ -1,3 +1,16 @@
+<?php
+/**
+ * Project: UpdateAPI
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
+ *
+ * File: footer.php
+ * Description: WordPress Update API
+ */
+
+?>
 </div>
 <footer>
     <p>&copy; <?php echo date("Y"); ?> Vontainment. All Rights Reserved.</p>

--- a/update-api/app/Views/layouts/header.php
+++ b/update-api/app/Views/layouts/header.php
@@ -1,3 +1,16 @@
+<?php
+/**
+ * Project: UpdateAPI
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
+ *
+ * File: header.php
+ * Description: WordPress Update API
+ */
+
+?>
 <!DOCTYPE html>
 <html lang="en-US">
 <head>

--- a/update-api/app/Views/login.php
+++ b/update-api/app/Views/login.php
@@ -1,3 +1,16 @@
+<?php
+/**
+ * Project: UpdateAPI
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
+ *
+ * File: login.php
+ * Description: WordPress Update API
+ */
+
+?>
 <!DOCTYPE html>
 <html lang="en-US">
 <head>

--- a/update-api/app/Views/logs.php
+++ b/update-api/app/Views/logs.php
@@ -1,11 +1,10 @@
 <?php
-
 /**
- * @package UpdateAPI
- * @author  Vontainment <services@vontainment.com>
- * @license https://opensource.org/licenses/MIT MIT License
- * @link    https://vontainment.com
- * @version 3.0.0
+ * Project: UpdateAPI
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
  *
  * File: logs.php
  * Description: WordPress Update API

--- a/update-api/app/Views/plupdate.php
+++ b/update-api/app/Views/plupdate.php
@@ -1,11 +1,10 @@
 <?php
-
 /**
- * @package UpdateAPI
- * @author  Vontainment <services@vontainment.com>
- * @license https://opensource.org/licenses/MIT MIT License
- * @link    https://vontainment.com
- * @version 3.0.0
+ * Project: UpdateAPI
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
  *
  * File: plupdate.php
  * Description: WordPress Update API

--- a/update-api/app/Views/thupdate.php
+++ b/update-api/app/Views/thupdate.php
@@ -1,11 +1,10 @@
 <?php
-
 /**
- * @package UpdateAPI
- * @author  Vontainment <services@vontainment.com>
- * @license https://opensource.org/licenses/MIT MIT License
- * @link    https://vontainment.com
- * @version 3.0.0
+ * Project: UpdateAPI
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
  *
  * File: thupdate.php
  * Description: WordPress Update API

--- a/update-api/config.php
+++ b/update-api/config.php
@@ -1,11 +1,10 @@
 <?php
-
 /**
- * @package UpdateAPI
- * @author  Vontainment <services@vontainment.com>
- * @license https://opensource.org/licenses/MIT MIT License
- * @link    https://vontainment.com
- * @version 3.0.0
+ * Project: UpdateAPI
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
  *
  * File: config.php
  * Description: WordPress Update API

--- a/update-api/public/api.php
+++ b/update-api/public/api.php
@@ -1,11 +1,10 @@
 <?php
-
 /**
- * @package UpdateAPI
- * @author  Vontainment <services@vontainment.com>
- * @license https://opensource.org/licenses/MIT MIT License
- * @link    https://vontainment.com
- * @version 3.0.0
+ * Project: UpdateAPI
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
  *
  * File: api.php
  * Description: WordPress Update API

--- a/update-api/public/index.php
+++ b/update-api/public/index.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Project: UpdateAPI
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
+ *
+ * File: index.php
+ * Description: WordPress Update API
+ */
 
 use App\Core\Router;
 


### PR DESCRIPTION
## Summary
- correct `@package` tags in plugin and theme updater headers

## Testing
- `php -l mu-plugin/v-sys-plugin-updater-mu.php`
- `php -l mu-plugin/v-sys-plugin-updater.php`
- `php -l mu-plugin/v-sys-theme-updater.php`


------
https://chatgpt.com/codex/tasks/task_e_686b6d23b8fc832a810bcb4c0ba650da