### PR TITLE
Implement logs handler and view update

### DIFF
--- a/update-api/app/Controllers/LogsController.php
+++ b/update-api/app/Controllers/LogsController.php
@@ -16,6 +16,21 @@ namespace App\Controllers;
 class LogsController
 {
     /**
+     * Handles the request for the logs page.
+     *
+     * Generates log output for plugins and themes and includes the log view.
+     *
+     * @return void
+     */
+    public static function handleRequest(): void
+    {
+        $ploutput = self::processLogFile('plugin.log');
+        $thoutput = self::processLogFile('theme.log');
+
+        require __DIR__ . '/../Views/logs.php';
+    }
+
+    /**
      * Processes a log file and generates HTML output.
      *
      * Reads the log file, groups entries by domain, and generates HTML for each entry.

--- a/update-api/app/Views/logs.php
+++ b/update-api/app/Views/logs.php
@@ -11,11 +11,7 @@
  * Description: WordPress Update API
  */
 
-use App\Controllers\LogsController;
-
 require_once __DIR__ . '/layouts/header.php';
-$ploutput = LogsController::processLogFile('plugin.log');
-$thoutput = LogsController::processLogFile('theme.log');
 
 ?>
 <div class="content-box">


### PR DESCRIPTION
## Summary
- add `handleRequest` to LogsController to generate and render log views
- simplify logs view to expect log outputs from controller

## Testing
- `php -l update-api/app/Controllers/LogsController.php`
- `php -l update-api/app/Views/logs.php`

------
https://chatgpt.com/codex/tasks/task_e_686b759ef30c832a99f07195f0d2ebce