### PR TITLE
Move errorhandler into ErrorMiddleware

### DIFF
--- a/update-api/app/Controllers/ApiController.php
+++ b/update-api/app/Controllers/ApiController.php
@@ -13,7 +13,7 @@
 namespace App\Controllers;
 
 use App\Core\Utility;
-use App\Core\ErrorHandler;
+use App\Core\ErrorMiddleware;
 
 class ApiController
 {
@@ -22,7 +22,7 @@ class ApiController
         $ip = $_SERVER['REMOTE_ADDR'];
         if (Utility::isBlacklisted($ip) || $_SERVER['REQUEST_METHOD'] !== 'GET') {
             http_response_code(403);
-            ErrorHandler::logMessage('Forbidden or invalid request from ' . $ip);
+            ErrorMiddleware::logMessage('Forbidden or invalid request from ' . $ip);
             exit();
         }
 
@@ -31,7 +31,7 @@ class ApiController
         foreach ($params as $p) {
             if (!isset($_GET[$p]) || $_GET[$p] === '' || ($p === 'type' && !in_array($_GET[$p], ['plugin', 'theme']))) {
                 http_response_code(400);
-                ErrorHandler::logMessage('Bad request missing parameter: ' . $p);
+                ErrorMiddleware::logMessage('Bad request missing parameter: ' . $p);
                 exit();
             }
             $values[] = $_GET[$p];
@@ -58,7 +58,7 @@ class ApiController
         }
         if (!empty($invalid)) {
             http_response_code(400);
-            ErrorHandler::logMessage('Bad request invalid parameter: ' . implode(', ', $invalid));
+            ErrorMiddleware::logMessage('Bad request invalid parameter: ' . implode(', ', $invalid));
             exit();
         }
 
@@ -94,7 +94,7 @@ class ApiController
                                         readfile($file_path);
                                         $log_message = $domain . ' ' . date('Y-m-d,h:i:sa') . ' Successful';
                                         file_put_contents($log, $log_message . PHP_EOL, LOCK_EX | FILE_APPEND);
-                                        ErrorHandler::logMessage($log_message, 'info');
+                                        ErrorMiddleware::logMessage($log_message, 'info');
                                         exit();
                                     }
                                 }
@@ -103,7 +103,7 @@ class ApiController
                         http_response_code(204);
                         $log_message = $domain . ' ' . date('Y-m-d,h:i:sa') . ' Successful';
                         file_put_contents($log, $log_message . PHP_EOL, LOCK_EX | FILE_APPEND);
-                        ErrorHandler::logMessage($log_message, 'info');
+                        ErrorMiddleware::logMessage($log_message, 'info');
                         exit();
                     }
                 }
@@ -114,7 +114,7 @@ class ApiController
         http_response_code(403);
         $log_message = $domain . ' ' . date('Y-m-d,h:i:sa') . ' Failed';
         file_put_contents($log, $log_message . PHP_EOL, LOCK_EX | FILE_APPEND);
-        ErrorHandler::logMessage($log_message);
+        ErrorMiddleware::logMessage($log_message);
         exit();
     }
 }

--- a/update-api/app/Controllers/AuthController.php
+++ b/update-api/app/Controllers/AuthController.php
@@ -14,7 +14,7 @@
 namespace App\Controllers;
 
 use App\Core\Utility;
-use App\Core\ErrorHandler;
+use App\Core\ErrorMiddleware;
 
 class AuthController
 {
@@ -47,12 +47,12 @@ class AuthController
             $ip = $_SERVER['REMOTE_ADDR'];
             if (Utility::isBlacklisted($ip)) {
                 $error = 'Your IP has been blacklisted due to multiple failed login attempts.';
-                ErrorHandler::logMessage($error);
+                ErrorMiddleware::logMessage($error);
                 $_SESSION['messages'][] = $error;
             } else {
                 Utility::updateFailedAttempts($ip);
                 $error = 'Invalid username or password.';
-                ErrorHandler::logMessage($error);
+                ErrorMiddleware::logMessage($error);
                 $_SESSION['messages'][] = $error;
             }
         }

--- a/update-api/app/Controllers/HomeController.php
+++ b/update-api/app/Controllers/HomeController.php
@@ -14,7 +14,7 @@
 namespace App\Controllers;
 
 use App\Core\Utility;
-use App\Core\ErrorHandler;
+use App\Core\ErrorMiddleware;
 
 class HomeController
 {
@@ -46,7 +46,7 @@ class HomeController
             }
         } else {
             $error = 'Invalid Form Action.';
-            ErrorHandler::logMessage($error);
+            ErrorMiddleware::logMessage($error);
             $_SESSION['messages'][] = $error;
             header('Location: /');
             exit();
@@ -69,7 +69,7 @@ class HomeController
         $new_entry = $safe_domain . ' ' . $safe_key;
         if (file_put_contents($hosts_file, $new_entry . "\n", FILE_APPEND | LOCK_EX) === false) {
             $error = 'Failed to add entry.';
-            ErrorHandler::logMessage($error);
+            ErrorMiddleware::logMessage($error);
             $_SESSION['messages'][] = $error;
         } else {
             $_SESSION['messages'][] = 'Entry added successfully.';
@@ -96,7 +96,7 @@ class HomeController
         $entries[$line_number] = $safe_domain . ' ' . $safe_key;
         if (file_put_contents($hosts_file, implode("\n", $entries) . "\n") === false) {
             $error = 'Failed to update entry.';
-            ErrorHandler::logMessage($error);
+            ErrorMiddleware::logMessage($error);
             $_SESSION['messages'][] = $error;
         } else {
             $_SESSION['messages'][] = 'Entry updated successfully.';
@@ -120,7 +120,7 @@ class HomeController
             !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])
         ) {
             $error = 'Invalid CSRF token.';
-            ErrorHandler::logMessage($error);
+            ErrorMiddleware::logMessage($error);
             $_SESSION['messages'][] = $error;
             header('Location: /home');
             exit();
@@ -131,7 +131,7 @@ class HomeController
         unset($entries[$line_number]);
         if (file_put_contents($hosts_file, implode("\n", $entries) . "\n") === false) {
             $error = 'Failed to delete entry.';
-            ErrorHandler::logMessage($error);
+            ErrorMiddleware::logMessage($error);
             $_SESSION['messages'][] = $error;
         }
 
@@ -149,7 +149,7 @@ class HomeController
                 });
                 if (file_put_contents($log_file_path, implode("\n", $filtered_entries) . "\n") === false) {
                     $error = 'Failed to update log file ' . $log_file_path;
-                    ErrorHandler::logMessage($error);
+                    ErrorMiddleware::logMessage($error);
                     $_SESSION['messages'][] = $error;
                 }
             }

--- a/update-api/app/Controllers/PluginsController.php
+++ b/update-api/app/Controllers/PluginsController.php
@@ -14,7 +14,7 @@
 namespace App\Controllers;
 
 use App\Core\Utility;
-use App\Core\ErrorHandler;
+use App\Core\ErrorMiddleware;
 
 class PluginsController
 {
@@ -44,7 +44,7 @@ class PluginsController
             }
         } else {
             $error = 'Invalid Form Action.';
-            ErrorHandler::logMessage($error);
+            ErrorMiddleware::logMessage($error);
             $_SESSION['messages'][] = $error;
             header('Location: /');
             exit();
@@ -86,7 +86,7 @@ class PluginsController
                 $error = 'Error uploading: ' .
                     htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8') .
                     '. Only .zip files are allowed.';
-                ErrorHandler::logMessage($error);
+                ErrorMiddleware::logMessage($error);
                 $_SESSION['messages'][] = $error;
                 continue;
             }
@@ -96,7 +96,7 @@ class PluginsController
                 $_SESSION['messages'][] = htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8') . ' uploaded successfully.';
             } else {
                 $error = 'Error uploading: ' . htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8');
-                ErrorHandler::logMessage($error);
+                ErrorMiddleware::logMessage($error);
                 $_SESSION['messages'][] = $error;
             }
         }
@@ -121,7 +121,7 @@ class PluginsController
             !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])
         ) {
             $error = 'Invalid CSRF token.';
-            ErrorHandler::logMessage($error);
+            ErrorMiddleware::logMessage($error);
             $_SESSION['messages'][] = $error;
             header('Location: /plupdate');
             exit();
@@ -138,7 +138,7 @@ class PluginsController
                 $_SESSION['messages'][] = 'Plugin deleted successfully!';
             } else {
                 $error = 'Failed to delete plugin file. Please try again.';
-                ErrorHandler::logMessage($error);
+                ErrorMiddleware::logMessage($error);
                 $_SESSION['messages'][] = $error;
             }
             header('Location: /plupdate');

--- a/update-api/app/Controllers/ThemesController.php
+++ b/update-api/app/Controllers/ThemesController.php
@@ -14,7 +14,7 @@
 namespace App\Controllers;
 
 use App\Core\Utility;
-use App\Core\ErrorHandler;
+use App\Core\ErrorMiddleware;
 
 class ThemesController
 {
@@ -42,7 +42,7 @@ class ThemesController
             }
         } else {
             $error = 'Invalid Form Action.';
-            ErrorHandler::logMessage($error);
+            ErrorMiddleware::logMessage($error);
             $_SESSION['messages'][] = $error;
             header('Location: /');
             exit();
@@ -84,7 +84,7 @@ class ThemesController
                 $error = 'Error uploading: ' .
                     htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8') .
                     '. Only .zip files are allowed.';
-                ErrorHandler::logMessage($error);
+                ErrorMiddleware::logMessage($error);
                 $_SESSION['messages'][] = $error;
                 continue;
             }
@@ -94,7 +94,7 @@ class ThemesController
                 $_SESSION['messages'][] = htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8') . ' uploaded successfully.';
             } else {
                 $error = 'Error uploading: ' . htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8');
-                ErrorHandler::logMessage($error);
+                ErrorMiddleware::logMessage($error);
                 $_SESSION['messages'][] = $error;
             }
         }
@@ -119,7 +119,7 @@ class ThemesController
             !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])
         ) {
             $error = 'Invalid CSRF token.';
-            ErrorHandler::logMessage($error);
+            ErrorMiddleware::logMessage($error);
             $_SESSION['messages'][] = $error;
             header('Location: /thupdate');
             exit();
@@ -136,7 +136,7 @@ class ThemesController
                 $_SESSION['messages'][] = 'Theme deleted successfully!';
             } else {
                 $error = 'Failed to delete theme file. Please try again.';
-                ErrorHandler::logMessage($error);
+                ErrorMiddleware::logMessage($error);
                 $_SESSION['messages'][] = $error;
             }
             header('Location: /thupdate');

--- a/update-api/app/Core/AuthMiddleware.php
+++ b/update-api/app/Core/AuthMiddleware.php
@@ -20,7 +20,7 @@ class AuthMiddleware
         $ip = filter_var($_SERVER['REMOTE_ADDR'] ?? '', FILTER_VALIDATE_IP);
         if ($ip && Utility::isBlacklisted($ip)) {
             http_response_code(403);
-            ErrorHandler::logMessage("Blacklisted IP attempted access: $ip", 'error');
+            ErrorMiddleware::logMessage("Blacklisted IP attempted access: $ip", 'error');
             exit();
         }
 

--- a/update-api/app/Core/ErrorMiddleware.php
+++ b/update-api/app/Core/ErrorMiddleware.php
@@ -7,7 +7,7 @@
  * Link:    https://vontainment.com
  * Version: 3.0.0
  *
- * File: ErrorHandler.php
+ * File: ErrorMiddleware.php
  * Description: WordPress Update API
  */
 
@@ -16,10 +16,10 @@ namespace App\Core;
 use ErrorException;
 use Throwable;
 
-class ErrorHandler
+class ErrorMiddleware
 {
     /**
-     * ErrorHandler constructor.
+     * ErrorMiddleware constructor.
      * Registers error, exception, and shutdown handlers.
      */
     public function __construct()

--- a/update-api/app/Views/layouts/footer.php
+++ b/update-api/app/Views/layouts/footer.php
@@ -17,6 +17,6 @@
     <p>&copy; <?php echo date("Y"); ?> Vontainment. All Rights Reserved.</p>
 </footer>
 <script src="/assets/js/footer-scripts.js"></script>
-<?php echo App\Core\ErrorHandler::displayAndClearMessages(); ?>
+<?php echo App\Core\ErrorMiddleware::displayAndClearMessages(); ?>
 </body>
 </html>

--- a/update-api/app/Views/login.php
+++ b/update-api/app/Views/login.php
@@ -36,6 +36,6 @@
             <input type="submit" value="Log In">
         </form>
     </div>
-    <?php echo App\Core\ErrorHandler::displayAndClearMessages(); ?>
+    <?php echo App\Core\ErrorMiddleware::displayAndClearMessages(); ?>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- rename `ErrorHandler.php` to `ErrorMiddleware.php`
- update all namespaces and references
- log blacklist messages via the new middleware

## Testing
- `php -l` on all PHP files

------
https://chatgpt.com/codex/tasks/task_e_686e26fbfa24832aa64bb9250bd8599e