### PR TITLE
Fix session cookie path

### DIFF
--- a/update-api/public/index.php
+++ b/update-api/public/index.php
@@ -17,6 +17,7 @@ use App\Core\ErrorMiddleware;
 
 $secureFlag = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off');
 session_set_cookie_params([
+                           'path'     => '/',
                            'httponly' => true,
                            'secure'   => $secureFlag,
                            'samesite' => 'Lax',


### PR DESCRIPTION
## Summary
- ensure session cookies apply site-wide by setting path to `/`

## Testing
- `php -l update-api/public/index.php`
- manual login & navigation with `php -S` and `curl`

------
https://chatgpt.com/codex/tasks/task_e_686e43f82028832a963d8ec57959c4ba