### PR TITLE
Validate host management entries

### DIFF
--- a/update-api/app/Controllers/HomeController.php
+++ b/update-api/app/Controllers/HomeController.php
@@ -63,6 +63,16 @@ class HomeController extends Controller
     }
     private static function addEntry(?string $domain, ?string $key): void
     {
+        $domain = $domain !== null ? Utility::validateDomain($domain) : null;
+        $key = $key !== null ? Utility::validateKey($key) : null;
+        if ($domain === null || $key === null) {
+            $error = 'Invalid domain or key.';
+            ErrorMiddleware::logMessage($error);
+            $_SESSION['messages'][] = $error;
+            header('Location: /home');
+            exit();
+        }
+
         $hosts_file = HOSTS_ACL . '/HOSTS';
         $safe_domain = htmlspecialchars($domain, ENT_QUOTES, 'UTF-8');
         $safe_key = htmlspecialchars($key, ENT_QUOTES, 'UTF-8');
@@ -89,6 +99,16 @@ class HomeController extends Controller
      */
     private static function updateEntry(?int $line_number, ?string $domain, ?string $key): void
     {
+        $domain = $domain !== null ? Utility::validateDomain($domain) : null;
+        $key = $key !== null ? Utility::validateKey($key) : null;
+        if ($domain === null || $key === null) {
+            $error = 'Invalid domain or key.';
+            ErrorMiddleware::logMessage($error);
+            $_SESSION['messages'][] = $error;
+            header('Location: /home');
+            exit();
+        }
+
         $hosts_file = HOSTS_ACL . '/HOSTS';
         $entries = file($hosts_file, FILE_IGNORE_NEW_LINES);
         $safe_domain = htmlspecialchars($domain, ENT_QUOTES, 'UTF-8');


### PR DESCRIPTION
## Summary
- ensure `addEntry` and `updateEntry` verify domain and key

## Testing
- `php -l update-api/app/Controllers/HomeController.php`
- `find update-api/app/Controllers -name '*.php' -print0 | xargs -0 -n1 php -l`
- `find update-api/app/Core -name '*.php' -print0 | xargs -0 -n1 php -l`
- `find update-api/app/Models -name '*.php' -print0 | xargs -0 -n1 php -l`
- `find update-api/app/Views -name '*.php' -print0 | xargs -0 -n1 php -l`
- `php -l update-api/autoload.php`
- `php -l update-api/public/index.php`


------
https://chatgpt.com/codex/tasks/task_e_686e46cee038832aa836c38f2f5f8ad7