### PR TITLE
Improve upload validation and page reload

### DIFF
--- a/update-api/app/Views/plupdate.php
+++ b/update-api/app/Views/plupdate.php
@@ -29,7 +29,7 @@ require_once __DIR__ . '/layouts/header.php';
           <input name="plugin_file[]" type="file" multiple />
         </div>
       </form>
-      <button class="reload-btn" onclick="window.location = '/plupdate'; window.location.reload();">Reload Page</button>
+      <button class="reload-btn" onclick="window.location.reload();">Reload Page</button>
     </div>
 
     <div id="message-container">
@@ -53,22 +53,18 @@ require_once __DIR__ . '/layouts/header.php';
         var dz = this;
 
         this.on("success", function(file, response) {
-          // File uploaded successfully
-          console.log(response); // You can handle the response from the server here
-
-          // Create a success message element
-          var successMsg = $('<div class="success-message">Successfully uploaded file: ' + file.name + '</div>');
+          console.log(response);
+          var successMsg = $('<div class="success-message"></div>');
+          successMsg.text(response);
 
           // Insert the success message below the form
           $('#message-container').append(successMsg);
         });
 
         this.on("error", function(file, errorMessage) {
-          // File upload error
           console.log(errorMessage);
-
-          // Create an error message element
-          var errorMsg = $('<div class="error-message">Error uploading file: ' + file.name + '</div>');
+          var errorMsg = $('<div class="error-message"></div>');
+          errorMsg.text(errorMessage);
 
           // Insert the error message below the form
           $('#message-container').append(errorMsg);

--- a/update-api/app/Views/thupdate.php
+++ b/update-api/app/Views/thupdate.php
@@ -29,7 +29,7 @@ require_once __DIR__ . '/layouts/header.php';
           <input name="theme_file[]" type="file" multiple />
         </div>
       </form>
-      <button class="reload-btn" onclick="window.location = '/thupdate'; window.location.reload();">Reload Page</button>
+      <button class="reload-btn" onclick="window.location.reload();">Reload Page</button>
     </div>
     <div id="message-container">
       <h2>Upload Status</h2>
@@ -52,24 +52,18 @@ require_once __DIR__ . '/layouts/header.php';
         var dz = this;
 
         this.on("success", function(file, response) {
-          // File uploaded successfully
-          console.log(response); // You can handle the response from the server here
+          console.log(response);
+          var successMsg = $('<div class="success-message"></div>');
+          successMsg.text(response);
 
-          // Create a success message element
-          var successMsg = $('<div class="success-message">Successfully uploaded file: ' + file.name + '</div>');
-
-          // Insert the success message below the form
           $('#message-container').append(successMsg);
         });
 
         this.on("error", function(file, errorMessage) {
-          // File upload error
           console.log(errorMessage);
+          var errorMsg = $('<div class="error-message"></div>');
+          errorMsg.text(errorMessage);
 
-          // Create an error message element
-          var errorMsg = $('<div class="error-message">Error uploading file: ' + file.name + '</div>');
-
-          // Insert the error message below the form
           $('#message-container').append(errorMsg);
         });
       }


### PR DESCRIPTION
## Summary
- return meaningful HTTP responses for plugin uploads
- support AJAX uploads in plugins and themes controllers
- display server messages in the UI
- simplify reload buttons so they don't drop session

## Testing
- `php -l update-api/app/Views/layouts/header.php`
- `php -l update-api/app/Views/layouts/footer.php`
- `php -l update-api/app/Views/logs.php`
- `php -l update-api/app/Views/thupdate.php`
- `php -l update-api/app/Views/plupdate.php`
- `php -l update-api/app/Core/Utility.php`
- `php -l update-api/app/Core/Router.php`
- `php -l update-api/app/Core/ErrorMiddleware.php`
- `php -l update-api/app/Core/AuthMiddleware.php`
- `php -l update-api/app/Core/Controller.php`
- `php -l update-api/app/Controllers/LogsController.php`
- `php -l update-api/app/Controllers/PluginsController.php`
- `php -l update-api/app/Controllers/AuthController.php`
- `php -l update-api/app/Controllers/ApiController.php`
- `php -l update-api/app/Controllers/ThemesController.php`
- `php -l update-api/app/Controllers/HomeController.php`
- `php -l update-api/app/Models/ThemeModel.php`
- `php -l update-api/app/Models/HostsModel.php`
- `php -l update-api/app/Models/PluginModel.php`
- `php -l update-api/app/Models/LogModel.php`

------
https://chatgpt.com/codex/tasks/task_e_686e47f10058832a80f0506df4575ef0