### PR TITLE
Add 404 error view

### DIFF
--- a/update-api/app/Core/Router.php
+++ b/update-api/app/Core/Router.php
@@ -50,7 +50,7 @@ class Router
                 break;
             default:
                 header('HTTP/1.0 404 Not Found');
-                echo '404 - Page Not Found';
+                require __DIR__ . '/../Views/404.php';
                 exit();
         }
     }

--- a/update-api/app/Views/404.php
+++ b/update-api/app/Views/404.php
@@ -1,0 +1,21 @@
+<?php
+// phpcs:ignoreFile PSR1.Files.SideEffects.FoundWithSymbols
+
+/**
+ * Project: UpdateAPI
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
+ *
+ * File: 404.php
+ * Description: WordPress Update API
+ */
+
+require_once __DIR__ . '/layouts/header.php';
+?>
+<div class="content-box">
+    <h2>404 - Page Not Found</h2>
+    <p>The page you are looking for does not exist.</p>
+</div>
+<?php require_once __DIR__ . '/layouts/footer.php'; ?>


### PR DESCRIPTION
## Summary
- provide a simple 404.php view
- load the view when no route matches

## Testing
- `php -l update-api/app/Views/404.php`
- `php -l update-api/app/Core/Router.php`
- `php -l update-api/public/index.php`


------
https://chatgpt.com/codex/tasks/task_e_686e4aef287c832a826050aaf524e9cc