### PR TITLE
Fix AJAX responses on plugin/theme errors

### DIFF
--- a/update-api/app/Controllers/PluginsController.php
+++ b/update-api/app/Controllers/PluginsController.php
@@ -46,6 +46,13 @@ class PluginsController extends Controller
             } else {
                 $error = 'Invalid Form Action.';
                 ErrorMiddleware::logMessage($error);
+                $isAjax = !empty($_SERVER['HTTP_X_REQUESTED_WITH']) &&
+                    strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest';
+                if ($isAjax) {
+                    http_response_code(400);
+                    echo $error;
+                    exit();
+                }
                 $_SESSION['messages'][] = $error;
                 header('Location: /');
                 exit();

--- a/update-api/app/Controllers/ThemesController.php
+++ b/update-api/app/Controllers/ThemesController.php
@@ -44,6 +44,13 @@ class ThemesController extends Controller
             } else {
                 $error = 'Invalid Form Action.';
                 ErrorMiddleware::logMessage($error);
+                $isAjax = !empty($_SERVER['HTTP_X_REQUESTED_WITH']) &&
+                    strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest';
+                if ($isAjax) {
+                    http_response_code(400);
+                    echo $error;
+                    exit();
+                }
                 $_SESSION['messages'][] = $error;
                 header('Location: /');
                 exit();


### PR DESCRIPTION
## Summary
- improve plugin and theme controllers to return plain text errors for AJAX requests

## Testing
- `php -l update-api/app/Controllers/PluginsController.php`
- `php -l update-api/app/Controllers/ThemesController.php`


------
https://chatgpt.com/codex/tasks/task_e_686e5ea8941c832aa25cd98de37377a4