### PR TITLE
Move filesystem logic into models

### DIFF
--- a/update-api/app/Controllers/LogsController.php
+++ b/update-api/app/Controllers/LogsController.php
@@ -15,6 +15,7 @@
 namespace App\Controllers;
 
 use App\Core\Controller;
+use App\Models\LogModel;
 
 class LogsController extends Controller
 {
@@ -27,8 +28,8 @@ class LogsController extends Controller
      */
     public static function handleRequest(): void
     {
-        $ploutput = self::processLogFile('plugin.log');
-        $thoutput = self::processLogFile('theme.log');
+        $ploutput = LogModel::processLogFile('plugin.log');
+        $thoutput = LogModel::processLogFile('theme.log');
 
         // Use the render method to include the logs view
         (new self())->render('logs', [
@@ -46,56 +47,4 @@ class LogsController extends Controller
      *
      * @return string The generated HTML output or an error message if the file is not found.
      */
-    public static function processLogFile(string $logFile): string
-    {
-        $log_file_path = LOG_DIR . "/$logFile";
-        $output = '';
-        if (file_exists($log_file_path)) {
-            $log_array = file($log_file_path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-            $log_by_domain = [];
-            foreach ($log_array as $entry) {
-                list($domain, $date, $status) = explode(' ', $entry, 3);
-                $log_by_domain[$domain] = [
-
-                                           'date'   => $date,
-                                           'status' => $status,
-                                          ];
-            }
-            ob_start();
-            echo '<div class="log-row">';
-            foreach ($log_by_domain as $domain => $entry) {
-                $date_diff = (strtotime(date('Y-m-d')) - strtotime($entry['date'])) / (60 * 60 * 24);
-                $classes = '';
-                if ($entry['status'] == 'Failed') {
-                    $classes .= ' error';
-                } elseif ($entry['status'] == 'Success') {
-                    $classes .= ' success';
-                }
-                if ($date_diff > 30) {
-                    $classes .= ' lost';
-                }
-                $classes = trim($classes);
-                echo '<div class="log-sub-box' . ($classes ? " $classes" : '') . '">';
-                echo '<h3>' . htmlspecialchars($domain, ENT_QUOTES, 'UTF-8') . '</h3>';
-                if ($entry['status'] == 'Failed') {
-                    echo '<p class="log-entry" style="color:red;">' .
-                        htmlspecialchars($entry['date'], ENT_QUOTES, 'UTF-8') . ' ' .
-                        htmlspecialchars($entry['status'], ENT_QUOTES, 'UTF-8') .
-                        '</p>';
-                } else {
-                    echo '<p class="log-entry" style="color:green;">' .
-                    htmlspecialchars($entry['date'], ENT_QUOTES, 'UTF-8') . ' ' .
-                    htmlspecialchars($entry['status'], ENT_QUOTES, 'UTF-8') .
-                    '</p>';
-                }
-                echo '</div>';
-            }
-            echo '</div>';
-            $output = ob_get_contents();
-            ob_end_clean();
-            return $output;
-        } else {
-            return 'Log file not found.';
-        }
-    }
 }

--- a/update-api/app/Models/HostsModel.php
+++ b/update-api/app/Models/HostsModel.php
@@ -16,4 +16,82 @@ namespace App\Models;
 class HostsModel
 {
     public static string $file = HOSTS_ACL . '/HOSTS';
+
+    /**
+     * Return all host file entries as array of lines.
+     *
+     * @return array
+     */
+    public static function getEntries(): array
+    {
+        return file_exists(self::$file) ? file(self::$file, FILE_IGNORE_NEW_LINES) : [];
+    }
+
+    /**
+     * Add an entry to the hosts file.
+     *
+     * @param string $domain
+     * @param string $key
+     *
+     * @return bool
+     */
+    public static function addEntry(string $domain, string $key): bool
+    {
+        $safe_domain = htmlspecialchars($domain, ENT_QUOTES, 'UTF-8');
+        $safe_key = htmlspecialchars($key, ENT_QUOTES, 'UTF-8');
+        $new_entry = $safe_domain . ' ' . $safe_key;
+        return file_put_contents(self::$file, $new_entry . "\n", FILE_APPEND | LOCK_EX) !== false;
+    }
+
+    /**
+     * Update an entry in the hosts file.
+     *
+     * @param int    $line
+     * @param string $domain
+     * @param string $key
+     *
+     * @return bool
+     */
+    public static function updateEntry(int $line, string $domain, string $key): bool
+    {
+        $entries = self::getEntries();
+        $safe_domain = htmlspecialchars($domain, ENT_QUOTES, 'UTF-8');
+        $safe_key = htmlspecialchars($key, ENT_QUOTES, 'UTF-8');
+        $entries[$line] = $safe_domain . ' ' . $safe_key;
+        return file_put_contents(self::$file, implode("\n", $entries) . "\n") !== false;
+    }
+
+    /**
+     * Delete an entry from the hosts file.
+     *
+     * @param int    $line
+     * @param string $domain
+     *
+     * @return bool
+     */
+    public static function deleteEntry(int $line, string $domain): bool
+    {
+        $entries = self::getEntries();
+        unset($entries[$line]);
+        $result = file_put_contents(self::$file, implode("\n", $entries) . "\n") !== false;
+
+        // also remove from log files
+        $log_files = [
+            'plugin.log',
+            'theme.log',
+        ];
+        $safe_domain = htmlspecialchars($domain, ENT_QUOTES, 'UTF-8');
+        foreach ($log_files as $log_file) {
+            $log_file_path = LOG_DIR . "/$log_file";
+            if (file_exists($log_file_path)) {
+                $log_entries = file($log_file_path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+                $filtered_entries = array_filter($log_entries, function ($entry) use ($safe_domain) {
+                    return strpos($entry, $safe_domain) !== 0 ? true : false;
+                });
+                file_put_contents($log_file_path, implode("\n", $filtered_entries) . "\n");
+            }
+        }
+
+        return $result;
+    }
 }

--- a/update-api/app/Models/LogModel.php
+++ b/update-api/app/Models/LogModel.php
@@ -16,4 +16,64 @@ namespace App\Models;
 class LogModel
 {
     public static string $dir = LOG_DIR;
+
+    /**
+     * Process a log file and generate grouped output.
+     *
+     * @param string $logFile
+     *
+     * @return string
+     */
+    public static function processLogFile(string $logFile): string
+    {
+        $log_file_path = self::$dir . "/$logFile";
+        $output = '';
+        if (file_exists($log_file_path)) {
+            $log_array = file($log_file_path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+            $log_by_domain = [];
+            foreach ($log_array as $entry) {
+                list($domain, $date, $status) = explode(' ', $entry, 3);
+                $log_by_domain[$domain] = [
+                    'date'   => $date,
+                    'status' => $status,
+                ];
+            }
+
+            ob_start();
+            echo '<div class="log-row">';
+            foreach ($log_by_domain as $domain => $entry) {
+                $date_diff = (strtotime(date('Y-m-d')) - strtotime($entry['date'])) / (60 * 60 * 24);
+                $classes = '';
+                if ($entry['status'] == 'Failed') {
+                    $classes .= ' error';
+                } elseif ($entry['status'] == 'Success') {
+                    $classes .= ' success';
+                }
+                if ($date_diff > 30) {
+                    $classes .= ' lost';
+                }
+                $classes = trim($classes);
+                echo '<div class="log-sub-box' . ($classes ? " $classes" : '') . '">';
+                echo '<h3>' . htmlspecialchars($domain, ENT_QUOTES, 'UTF-8') . '</h3>';
+                if ($entry['status'] == 'Failed') {
+                    echo '<p class="log-entry" style="color:red;">' .
+                        htmlspecialchars($entry['date'], ENT_QUOTES, 'UTF-8') . ' ' .
+                        htmlspecialchars($entry['status'], ENT_QUOTES, 'UTF-8') .
+                        '</p>';
+                } else {
+                    echo '<p class="log-entry" style="color:green;">' .
+                        htmlspecialchars($entry['date'], ENT_QUOTES, 'UTF-8') . ' ' .
+                        htmlspecialchars($entry['status'], ENT_QUOTES, 'UTF-8') .
+                        '</p>';
+                }
+                echo '</div>';
+            }
+            echo '</div>';
+            $output = ob_get_contents();
+            ob_end_clean();
+            return $output;
+        }
+
+        return 'Log file not found.';
+    }
 }

--- a/update-api/app/Models/PluginModel.php
+++ b/update-api/app/Models/PluginModel.php
@@ -13,7 +13,96 @@
 
 namespace App\Models;
 
+use App\Core\Utility;
+
 class PluginModel
 {
     public static string $dir = PLUGINS_DIR;
+
+    /**
+     * Return array of plugin file paths.
+     *
+     * @return array
+     */
+    public static function getPlugins(): array
+    {
+        $plugins = glob(self::$dir . '/*.zip');
+        return array_reverse($plugins ?: []);
+    }
+
+    /**
+     * Delete a plugin file.
+     *
+     * @param string $plugin_name
+     *
+     * @return bool True on success, false otherwise.
+     */
+    public static function deletePlugin(string $plugin_name): bool
+    {
+        $plugin_path = self::$dir . '/' . basename($plugin_name);
+        if (
+            file_exists($plugin_path) &&
+            dirname(realpath($plugin_path)) === realpath(self::$dir)
+        ) {
+            return unlink($plugin_path);
+        }
+
+        return false;
+    }
+
+    /**
+     * Upload plugin files.
+     *
+     * @param array $fileArray $_FILES['plugin_file'] array structure
+     * @param bool  $isAjax    Whether the request was via AJAX
+     *
+     * @return array Array of status messages
+     */
+    public static function uploadFiles(array $fileArray, bool $isAjax = false): array
+    {
+        $messages = [];
+        $allowed_extensions = ['zip'];
+        $total_files = count($fileArray['name']);
+
+        for ($i = 0; $i < $total_files; $i++) {
+            $file_name = isset($fileArray['name'][$i]) ? Utility::validateFilename($fileArray['name'][$i]) : '';
+            $file_tmp = isset($fileArray['tmp_name'][$i]) ? $fileArray['tmp_name'][$i] : '';
+            $file_error = isset($fileArray['error'][$i]) ? filter_var($fileArray['error'][$i], FILTER_VALIDATE_INT) : UPLOAD_ERR_NO_FILE;
+            $file_extension = strtolower(pathinfo($file_name, PATHINFO_EXTENSION));
+
+            $plugin_slug = explode('_', $file_name)[0];
+            $existing_plugins = glob(self::$dir . '/' . $plugin_slug . '_*');
+            foreach ($existing_plugins as $plugin) {
+                if (is_file($plugin)) {
+                    unlink($plugin);
+                }
+            }
+
+            $max_upload_size = min(
+                (int)(ini_get('upload_max_filesize') * 1024 * 1024),
+                (int)(ini_get('post_max_size') * 1024 * 1024)
+            );
+
+            if ($fileArray['size'][$i] > $max_upload_size) {
+                $messages[] = 'Error uploading: ' . htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8') .
+                    '. File size exceeds the maximum allowed size of ' . ($max_upload_size / (1024 * 1024)) . ' MB.';
+                continue;
+            }
+
+            if ($file_error !== UPLOAD_ERR_OK || !in_array($file_extension, $allowed_extensions)) {
+                $messages[] = 'Error uploading: ' . htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8') .
+                    '. Only .zip files are allowed, and filenames must follow the format: plugin-name_1.0.zip';
+                continue;
+            }
+
+            $plugin_path = self::$dir . '/' . $file_name;
+            if (move_uploaded_file($file_tmp, $plugin_path)) {
+                $messages[] = htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8') . ' uploaded successfully.';
+            } else {
+                $messages[] = 'Error uploading: ' . htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8');
+            }
+        }
+
+        return $messages;
+    }
 }

--- a/update-api/app/Models/ThemeModel.php
+++ b/update-api/app/Models/ThemeModel.php
@@ -13,7 +13,96 @@
 
 namespace App\Models;
 
+use App\Core\Utility;
+
 class ThemeModel
 {
     public static string $dir = THEMES_DIR;
+
+    /**
+     * Return array of theme file paths.
+     *
+     * @return array
+     */
+    public static function getThemes(): array
+    {
+        $themes = glob(self::$dir . '/*.zip');
+        return array_reverse($themes ?: []);
+    }
+
+    /**
+     * Delete a theme file.
+     *
+     * @param string $theme_name
+     *
+     * @return bool True on success, false otherwise.
+     */
+    public static function deleteTheme(string $theme_name): bool
+    {
+        $theme_path = self::$dir . '/' . basename($theme_name);
+        if (
+            file_exists($theme_path) &&
+            dirname(realpath($theme_path)) === realpath(self::$dir)
+        ) {
+            return unlink($theme_path);
+        }
+
+        return false;
+    }
+
+    /**
+     * Upload theme files.
+     *
+     * @param array $fileArray $_FILES['theme_file'] array structure
+     * @param bool  $isAjax    Whether the request was via AJAX
+     *
+     * @return array Array of status messages
+     */
+    public static function uploadFiles(array $fileArray, bool $isAjax = false): array
+    {
+        $messages = [];
+        $allowed_extensions = ['zip'];
+        $total_files = count($fileArray['name']);
+
+        for ($i = 0; $i < $total_files; $i++) {
+            $file_name = isset($fileArray['name'][$i]) ? Utility::validateFilename($fileArray['name'][$i]) : '';
+            $file_tmp = isset($fileArray['tmp_name'][$i]) ? $fileArray['tmp_name'][$i] : '';
+            $file_error = isset($fileArray['error'][$i]) ? filter_var($fileArray['error'][$i], FILTER_VALIDATE_INT) : UPLOAD_ERR_NO_FILE;
+            $file_extension = strtolower(pathinfo($file_name, PATHINFO_EXTENSION));
+
+            $theme_slug = explode('_', $file_name)[0];
+            $existing_themes = glob(self::$dir . '/' . $theme_slug . '_*');
+            foreach ($existing_themes as $theme) {
+                if (is_file($theme)) {
+                    unlink($theme);
+                }
+            }
+
+            $max_upload_size = min(
+                (int)(ini_get('upload_max_filesize') * 1024 * 1024),
+                (int)(ini_get('post_max_size') * 1024 * 1024)
+            );
+
+            if ($fileArray['size'][$i] > $max_upload_size) {
+                $messages[] = 'Error uploading: ' . htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8') .
+                    '. File size exceeds the maximum allowed size of ' . ($max_upload_size / (1024 * 1024)) . ' MB.';
+                continue;
+            }
+
+            if ($file_error !== UPLOAD_ERR_OK || !in_array($file_extension, $allowed_extensions)) {
+                $messages[] = 'Error uploading: ' . htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8') .
+                    '. Only .zip files are allowed, and filenames must follow the format: theme-name_1.0.zip';
+                continue;
+            }
+
+            $theme_path = self::$dir . '/' . $file_name;
+            if (move_uploaded_file($file_tmp, $theme_path)) {
+                $messages[] = htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8') . ' uploaded successfully.';
+            } else {
+                $messages[] = 'Error uploading: ' . htmlspecialchars($file_name, ENT_QUOTES, 'UTF-8');
+            }
+        }
+
+        return $messages;
+    }
 }


### PR DESCRIPTION
## Summary
- move plugin and theme file management into their models
- move host file operations into `HostsModel`
- move log file parsing into `LogModel`
- update controllers to use the new model methods

## Testing
- `php -l` on all PHP files

------
https://chatgpt.com/codex/tasks/task_e_686e69496154832a95a41d9fa80f5759