### PR TITLE
Fix dangling docblock in LogsController

### DIFF
--- a/update-api/app/Controllers/LogsController.php
+++ b/update-api/app/Controllers/LogsController.php
@@ -38,13 +38,4 @@ class LogsController extends Controller
         ]);
     }
 
-    /**
-     * Processes a log file and generates HTML output.
-     *
-     * Reads the log file, groups entries by domain, and generates HTML for each entry.
-     *
-     * @param string $logFile The name of the log file to process.
-     *
-     * @return string The generated HTML output or an error message if the file is not found.
-     */
 }


### PR DESCRIPTION
## Summary
- remove stray docblock in `LogsController`

## Testing
- `php -l update-api/app/Controllers/LogsController.php`
- `php -l update-api/app/Models/LogModel.php`


------
https://chatgpt.com/codex/tasks/task_e_686e700774d0832a808e47f771ad07f1