### PR TITLE
Encrypt host keys with AES-256-CBC

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,14 +465,19 @@ The v-wordpress-plugin-updater project is designed to streamline the management 
    mkdir -p /storage/logs
    ```
 3. Edit `/config.php` and set the login credentials and directory constants. Adjust `VALID_USERNAME`, `VALID_PASSWORD`, and paths under `BASE_DIR` if the defaults do not match your setup.
-4. Define the API constants used by the mu-plugins in your WordPress `wp-config.php`:
+4. Set an `ENCRYPTION_KEY` environment variable used to secure host keys:
+
+   ```sh
+   export ENCRYPTION_KEY="your-32-byte-secret"
+   ```
+5. Define the API constants used by the mu-plugins in your WordPress `wp-config.php`:
 
    ```php
    define('VONTMENT_KEY', 'your-api-key');
    define('VONTMENT_PLUGINS', 'https://example.com/api');
    define('VONTMENT_THEMES', 'https://example.com/api');
    ```
-5. Ensure the web server user owns the `/storage` directory so uploads and logs can be written.
+6. Ensure the web server user owns the `/storage` directory so uploads and logs can be written.
 
 NOTE: Make sure to set /public/ as doc root. 
 

--- a/update-api/app/Controllers/ApiController.php
+++ b/update-api/app/Controllers/ApiController.php
@@ -85,8 +85,9 @@ class ApiController extends Controller
             while (($line = fgets($host_file)) !== false) {
                 $line = trim($line);
                 if ($line) {
-                    list($host, $host_key) = explode(' ', $line);
-                    if ($host === $domain && $host_key === $key) {
+                    list($host, $host_key) = explode(' ', $line, 2);
+                    $host_key = Utility::decrypt($host_key);
+                    if ($host === $domain && $host_key !== null && $host_key === $key) {
                         fclose($host_file);
                         foreach (scandir($dir) as $filename) {
                             if ($filename === '.' || $filename === '..') {

--- a/update-api/app/Controllers/HomeController.php
+++ b/update-api/app/Controllers/HomeController.php
@@ -141,7 +141,8 @@ class HomeController extends Controller
             // Correct line number for column 1
                 $fields = explode(' ', $entry);
                 $domain = isset($fields[0]) ? $fields[0] : '';
-                $key = isset($fields[1]) ? $fields[1] : '';
+                $encryptedKey = $fields[1] ?? '';
+                $key = Utility::decrypt($encryptedKey) ?? '';
                 $hostsTableHtml .= self::generateHostsTableRow($lineNumber, $domain, $key);
             }
 
@@ -162,7 +163,8 @@ class HomeController extends Controller
         // Correct line number for column 2
                 $fields = explode(' ', $entry);
                 $domain = isset($fields[0]) ? $fields[0] : '';
-                $key = isset($fields[1]) ? $fields[1] : '';
+                $encryptedKey = $fields[1] ?? '';
+                $key = Utility::decrypt($encryptedKey) ?? '';
                 $hostsTableHtml .= self::generateHostsTableRow($lineNumber, $domain, $key);
             }
 

--- a/update-api/app/Core/Utility.php
+++ b/update-api/app/Core/Utility.php
@@ -107,6 +107,49 @@ class Utility
     }
 
     /**
+     * Encrypt a string using AES-256-CBC.
+     *
+     * @param string $plain Plain text to encrypt.
+     * @return string Base64-encoded cipher text.
+     */
+    public static function encrypt(string $plain): string
+    {
+        $key = hash('sha256', ENCRYPTION_KEY, true);
+        $iv_length = openssl_cipher_iv_length('aes-256-cbc');
+        $iv = random_bytes($iv_length);
+        $cipher = openssl_encrypt($plain, 'aes-256-cbc', $key, OPENSSL_RAW_DATA, $iv);
+        return base64_encode($iv . $cipher);
+    }
+
+    /**
+     * Decrypt a string encrypted with encrypt().
+     *
+     * @param string $cipher Base64-encoded cipher text.
+     * @return string|null Decrypted plain text or null on failure.
+     */
+    public static function decrypt(string $cipher): ?string
+    {
+        $data = base64_decode($cipher, true);
+        if ($data === false) {
+            return null;
+        }
+        $iv_length = openssl_cipher_iv_length('aes-256-cbc');
+        if (strlen($data) <= $iv_length) {
+            return null;
+        }
+        $iv = substr($data, 0, $iv_length);
+        $cipher_text = substr($data, $iv_length);
+        $plain = openssl_decrypt(
+            $cipher_text,
+            'aes-256-cbc',
+            hash('sha256', ENCRYPTION_KEY, true),
+            OPENSSL_RAW_DATA,
+            $iv
+        );
+        return $plain === false ? null : $plain;
+    }
+
+    /**
      * Update the number of failed login attempts for an IP address and blacklist if necessary.
      *
      * @param string $ip The IP address to update.

--- a/update-api/app/Models/HostsModel.php
+++ b/update-api/app/Models/HostsModel.php
@@ -14,6 +14,8 @@
 
 namespace App\Models;
 
+use App\Core\Utility;
+
 class HostsModel
 {
     public static string $file = HOSTS_ACL . '/HOSTS';
@@ -40,7 +42,7 @@ class HostsModel
     {
         $safe_domain = htmlspecialchars($domain, ENT_QUOTES, 'UTF-8');
         $safe_key = htmlspecialchars($key, ENT_QUOTES, 'UTF-8');
-        $new_entry = $safe_domain . ' ' . $safe_key;
+        $new_entry = $safe_domain . ' ' . Utility::encrypt($safe_key);
         return file_put_contents(self::$file, $new_entry . "\n", FILE_APPEND | LOCK_EX) !== false;
     }
 
@@ -58,7 +60,7 @@ class HostsModel
         $entries = self::getEntries();
         $safe_domain = htmlspecialchars($domain, ENT_QUOTES, 'UTF-8');
         $safe_key = htmlspecialchars($key, ENT_QUOTES, 'UTF-8');
-        $entries[$line] = $safe_domain . ' ' . $safe_key;
+        $entries[$line] = $safe_domain . ' ' . Utility::encrypt($safe_key);
         return file_put_contents(self::$file, implode("\n", $entries) . "\n") !== false;
     }
 

--- a/update-api/config.php
+++ b/update-api/config.php
@@ -14,6 +14,8 @@
 define('VALID_USERNAME', 'admin');
 define('VALID_PASSWORD', 'password');
 
+define('ENCRYPTION_KEY', getenv('ENCRYPTION_KEY') ?: '');
+
 define('SESSION_TIMEOUT_LIMIT', 1800);
 
 define('BASE_DIR', dirname($_SERVER['DOCUMENT_ROOT']));


### PR DESCRIPTION
## Summary
- Securely configure `ENCRYPTION_KEY` via environment variable
- Add AES-256-CBC encrypt/decrypt helpers
- Encrypt stored host keys and decrypt for display and API validation
- Document `ENCRYPTION_KEY` setup

## Testing
- `php -l update-api/config.php`
- `php -l update-api/app/Core/Utility.php`
- `php -l update-api/app/Models/HostsModel.php`
- `php -l update-api/app/Controllers/HomeController.php`
- `php -l update-api/app/Controllers/ApiController.php`


------
https://chatgpt.com/codex/tasks/task_e_689d009a1d04832ab43c68b7353bf0f3