### PR TITLE
Auto-generate host keys and enable clipboard copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,14 +465,19 @@ The v-wordpress-plugin-updater project is designed to streamline the management 
    mkdir -p /storage/logs
    ```
 3. Edit `/config.php` and set the login credentials and directory constants. Adjust `VALID_USERNAME`, `VALID_PASSWORD`, and paths under `BASE_DIR` if the defaults do not match your setup.
-4. Define the API constants used by the mu-plugins in your WordPress `wp-config.php`:
+4. Set an `ENCRYPTION_KEY` environment variable used to secure host keys:
+
+   ```sh
+   export ENCRYPTION_KEY="your-32-byte-secret"
+   ```
+5. Define the API constants used by the mu-plugins in your WordPress `wp-config.php`:
 
    ```php
    define('VONTMENT_KEY', 'your-api-key');
    define('VONTMENT_PLUGINS', 'https://example.com/api');
    define('VONTMENT_THEMES', 'https://example.com/api');
    ```
-5. Ensure the web server user owns the `/storage` directory so uploads and logs can be written.
+6. Ensure the web server user owns the `/storage` directory so uploads and logs can be written.
 
 NOTE: Make sure to set /public/ as doc root. 
 

--- a/update-api/app/Controllers/ApiController.php
+++ b/update-api/app/Controllers/ApiController.php
@@ -85,8 +85,9 @@ class ApiController extends Controller
             while (($line = fgets($host_file)) !== false) {
                 $line = trim($line);
                 if ($line) {
-                    list($host, $host_key) = explode(' ', $line);
-                    if ($host === $domain && $host_key === $key) {
+                    list($host, $host_key) = explode(' ', $line, 2);
+                    $host_key = Utility::decrypt($host_key);
+                    if ($host === $domain && $host_key !== null && $host_key === $key) {
                         fclose($host_file);
                         foreach (scandir($dir) as $filename) {
                             if ($filename === '.' || $filename === '..') {

--- a/update-api/app/Models/HostsModel.php
+++ b/update-api/app/Models/HostsModel.php
@@ -14,6 +14,8 @@
 
 namespace App\Models;
 
+use App\Core\Utility;
+
 class HostsModel
 {
     public static string $file = HOSTS_ACL . '/HOSTS';
@@ -40,7 +42,7 @@ class HostsModel
     {
         $safe_domain = htmlspecialchars($domain, ENT_QUOTES, 'UTF-8');
         $safe_key = htmlspecialchars($key, ENT_QUOTES, 'UTF-8');
-        $new_entry = $safe_domain . ' ' . $safe_key;
+        $new_entry = $safe_domain . ' ' . Utility::encrypt($safe_key);
         return file_put_contents(self::$file, $new_entry . "\n", FILE_APPEND | LOCK_EX) !== false;
     }
 
@@ -58,7 +60,7 @@ class HostsModel
         $entries = self::getEntries();
         $safe_domain = htmlspecialchars($domain, ENT_QUOTES, 'UTF-8');
         $safe_key = htmlspecialchars($key, ENT_QUOTES, 'UTF-8');
-        $entries[$line] = $safe_domain . ' ' . $safe_key;
+        $entries[$line] = $safe_domain . ' ' . Utility::encrypt($safe_key);
         return file_put_contents(self::$file, implode("\n", $entries) . "\n") !== false;
     }
 

--- a/update-api/app/Views/home.php
+++ b/update-api/app/Views/home.php
@@ -31,10 +31,6 @@ require_once __DIR__ . '/layouts/header.php';
                 <input type="text" name="domain" id="domain" required>
             </div>
             <div class="form-group">
-                <label for="key">Key:</label>
-                <input type="text" name="key" id="key" required>
-            </div>
-            <div class="form-group">
                 <input type="submit" name="add_entry" value="Add Entry">
             </div>
         </form>

--- a/update-api/config.php
+++ b/update-api/config.php
@@ -14,6 +14,8 @@
 define('VALID_USERNAME', 'admin');
 define('VALID_PASSWORD', 'password');
 
+define('ENCRYPTION_KEY', getenv('ENCRYPTION_KEY') ?: '');
+
 define('SESSION_TIMEOUT_LIMIT', 1800);
 
 define('BASE_DIR', dirname($_SERVER['DOCUMENT_ROOT']));

--- a/update-api/public/assets/css/mobile.css
+++ b/update-api/public/assets/css/mobile.css
@@ -38,14 +38,17 @@
     width: 90%;
   }
 
+  .hosts-key {
+    cursor: pointer;
+  }
+
   .hosts-submit {
     margin-top: 5px;
     margin-bottom: 5px;
     width: 100%;
   }
 
-  #domain,
-  #key {
+  #domain {
     width: 100%;
   }
 

--- a/update-api/public/assets/css/styles.css
+++ b/update-api/public/assets/css/styles.css
@@ -191,12 +191,15 @@ APP LAYOUT & CONTENT
   width: 90%;
 }
 
+.hosts-key {
+  cursor: pointer;
+}
+
 .hosts-submit {
   width: 48%;
 }
 
-#domain,
-#key {
+#domain {
   width: 90%;
 }
 

--- a/update-api/public/assets/js/header-scripts.js
+++ b/update-api/public/assets/js/header-scripts.js
@@ -21,3 +21,12 @@ function showToast(message) {
         }, 500);
     }, 3000);
 }
+
+document.addEventListener("click", (e) => {
+    if (e.target.classList.contains("hosts-key")) {
+        const key = e.target.value;
+        navigator.clipboard.writeText(key).then(() => {
+            showToast("Key copied to clipboard");
+        });
+    }
+});


### PR DESCRIPTION
## Summary
- Auto-generate API keys when adding or regenerating host entries and provide a utility helper for key creation
- Make host keys read-only in the admin table with a Regen action that refreshes keys automatically
- Copy keys to the clipboard on click and update styles for better UX

## Testing
- `php -l app/Core/Utility.php`
- `php -l app/Controllers/HomeController.php`
- `php -l app/Views/home.php`


------
https://chatgpt.com/codex/tasks/task_e_689d009a1d04832ab43c68b7353bf0f3