### PR TITLE
refactor: split utility into validation and blacklist helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+## Unreleased
+- Moved validation and encryption utilities to `App\Helpers\Validation`.
+- Added `App\Models\Blacklist` for IP blacklist management and removed `App\Core\Utility`.

--- a/README.md
+++ b/README.md
@@ -85,11 +85,12 @@ The v-wordpress-plugin-updater project is designed to streamline the management 
     │   │   │   ├── AuthMiddleware.php
     │   │   │   ├── Controller.php
     │   │   │   ├── ErrorManager.php
-    │   │   │   ├── Router.php
-    │   │   │   └── Utility.php
+    │   │   │   └── Router.php
     │   │   ├── Helpers
-    │   │   │   └── MessageHelper.php
+    │   │   │   ├── MessageHelper.php
+    │   │   │   └── Validation.php
     │   │   ├── Models
+    │   │   │   ├── Blacklist.php
     │   │   │   ├── HostsModel.php
     │   │   │   ├── LogModel.php
     │   │   │   ├── PluginModel.php
@@ -144,7 +145,7 @@ The v-wordpress-plugin-updater project is designed to streamline the management 
 			<div class='directory-path' style='padding: 8px 0; color: #666;'>
 				<code><b>⦿ __root__</b></code>
 			<table style='width: 100%; border-collapse: collapse;'>
-			<thead>
+                                                          <thead>
 				<tr style='background-color: #f8f9fa;'>
 					<th style='width: 30%; text-align: left; padding: 8px;'>File Name</th>
 					<th style='text-align: left; padding: 8px;'>Summary</th>
@@ -233,11 +234,15 @@ The v-wordpress-plugin-updater project is designed to streamline the management 
 									<th style='width: 30%; text-align: left; padding: 8px;'>File Name</th>
 									<th style='text-align: left; padding: 8px;'>Summary</th>
 								</tr>
-							</thead>
-								<tr style='border-bottom: 1px solid #eee;'>
-									<td style='padding: 8px;'><b><a href='https://github.com/djav1985/v-wordpress-plugin-updater/blob/master/update-api/app/Models/ThemeModel.php'>ThemeModel.php</a></b></td>
-									<td style='padding: 8px;'>- Manages theme files within the WordPress Update API, enabling retrieval, deletion, and uploading of theme ZIP packages<br>- Facilitates theme lifecycle operations, ensuring proper file handling, validation, and size restrictions to support seamless theme management in the broader update infrastructure.</td>
-								</tr>
+                                                          </thead>
+                                                                  <tr style='border-bottom: 1px solid #eee;'>
+                                                                          <td style='padding: 8px;'><b><a href='https://github.com/djav1985/v-wordpress-plugin-updater/blob/master/update-api/app/Models/Blacklist.php'>Blacklist.php</a></b></td>
+                                                                          <td style='padding: 8px;'>- Tracks failed login attempts and manages IP blacklisting for the Update API, automatically expiring bans after a defined period to maintain security.</td>
+                                                                  </tr>
+                                                                  <tr style='border-bottom: 1px solid #eee;'>
+                                                                          <td style='padding: 8px;'><b><a href='https://github.com/djav1985/v-wordpress-plugin-updater/blob/master/update-api/app/Models/ThemeModel.php'>ThemeModel.php</a></b></td>
+                                                                          <td style='padding: 8px;'>- Manages theme files within the WordPress Update API, enabling retrieval, deletion, and uploading of theme ZIP packages<br>- Facilitates theme lifecycle operations, ensuring proper file handling, validation, and size restrictions to support seamless theme management in the broader update infrastructure.</td>
+                                                                  </tr>
 								<tr style='border-bottom: 1px solid #eee;'>
 									<td style='padding: 8px;'><b><a href='https://github.com/djav1985/v-wordpress-plugin-updater/blob/master/update-api/app/Models/HostsModel.php'>HostsModel.php</a></b></td>
 									<td style='padding: 8px;'>- Manages host entries within the WordPress Update API by providing functionalities to retrieve, add, update, and delete host records<br>- Ensures consistent handling of host data, maintains log integrity, and supports dynamic configuration of host access controls, integral to the overall architecture for secure and flexible update management.</td>
@@ -266,10 +271,6 @@ The v-wordpress-plugin-updater project is designed to streamline the management 
 									<th style='text-align: left; padding: 8px;'>Summary</th>
 								</tr>
 							</thead>
-								<tr style='border-bottom: 1px solid #eee;'>
-									<td style='padding: 8px;'><b><a href='https://github.com/djav1985/v-wordpress-plugin-updater/blob/master/update-api/app/Core/Utility.php'>Utility.php</a></b></td>
-									<td style='padding: 8px;'>- Provides utility functions for validating domain names, API keys, slugs, filenames, versions, usernames, and passwords within the WordPress Update API<br>- Manages IP-based security by tracking failed login attempts and maintaining a blacklist, ensuring enhanced security and integrity across the update process<br>- Integral to maintaining data validation standards and safeguarding the API against unauthorized access.</td>
-								</tr>
 								<tr style='border-bottom: 1px solid #eee;'>
 									<td style='padding: 8px;'><b><a href='https://github.com/djav1985/v-wordpress-plugin-updater/blob/master/update-api/app/Core/Router.php'>Router.php</a></b></td>
 									<td style='padding: 8px;'>- Defines the core routing mechanism for the WordPress Update API, directing incoming requests to appropriate controllers based on URL paths<br>- Ensures authentication for protected routes and handles URL redirection and error responses, facilitating seamless request handling within the applications architecture.</td>

--- a/update-api/app/Controllers/ApiController.php
+++ b/update-api/app/Controllers/ApiController.php
@@ -14,7 +14,8 @@
 
 namespace App\Controllers;
 
-use App\Core\Utility;
+use App\Helpers\Validation;
+use App\Models\Blacklist;
 use App\Core\ErrorManager;
 use App\Core\Controller;
 
@@ -23,7 +24,7 @@ class ApiController extends Controller
     public static function handleRequest(): void
     {
         $ip = $_SERVER['REMOTE_ADDR'];
-        if (Utility::isBlacklisted($ip) || $_SERVER['REQUEST_METHOD'] !== 'GET') {
+        if (Blacklist::isBlacklisted($ip) || $_SERVER['REQUEST_METHOD'] !== 'GET') {
             http_response_code(403);
             ErrorManager::getInstance()->log('Forbidden or invalid request from ' . $ip);
             exit();
@@ -47,10 +48,10 @@ class ApiController extends Controller
         }
         list($type, $domain, $key, $slug, $version) = $values;
 
-        $domain  = Utility::validateDomain($domain);
-        $key     = Utility::validateKey($key);
-        $slug    = Utility::validateSlug($slug);
-        $version = Utility::validateVersion($version);
+        $domain  = Validation::validateDomain($domain);
+        $key     = Validation::validateKey($key);
+        $slug    = Validation::validateSlug($slug);
+        $version = Validation::validateVersion($version);
 
         $invalid = [];
         if ($domain === null) {
@@ -86,7 +87,7 @@ class ApiController extends Controller
                 $line = trim($line);
                 if ($line) {
                     list($host, $host_key) = explode(' ', $line, 2);
-                    $host_key = Utility::decrypt($host_key);
+                    $host_key = Validation::decrypt($host_key);
                     if ($host === $domain && $host_key !== null && $host_key === $key) {
                         fclose($host_file);
                         foreach (scandir($dir) as $filename) {

--- a/update-api/app/Controllers/AuthController.php
+++ b/update-api/app/Controllers/AuthController.php
@@ -15,7 +15,8 @@
 namespace App\Controllers;
 
 use App\Core\Controller;
-use App\Core\Utility;
+use App\Helpers\Validation;
+use App\Models\Blacklist;
 use App\Core\ErrorManager;
 use App\Helpers\MessageHelper;
 
@@ -34,8 +35,8 @@ class AuthController extends Controller
         }
 
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-            $username = isset($_POST['username']) ? Utility::validateUsername($_POST['username']) : null;
-            $password = isset($_POST['password']) ? Utility::validatePassword($_POST['password']) : null;
+            $username = isset($_POST['username']) ? Validation::validateUsername($_POST['username']) : null;
+            $password = isset($_POST['password']) ? Validation::validatePassword($_POST['password']) : null;
 
             if ($username === VALID_USERNAME && $password === VALID_PASSWORD) {
                 $_SESSION['logged_in'] = true;
@@ -48,12 +49,12 @@ class AuthController extends Controller
             }
 
             $ip = $_SERVER['REMOTE_ADDR'];
-            if (Utility::isBlacklisted($ip)) {
+            if (Blacklist::isBlacklisted($ip)) {
                 $error = 'Your IP has been blacklisted due to multiple failed login attempts.';
                 ErrorManager::getInstance()->log($error);
                 MessageHelper::addMessage($error);
             } else {
-                Utility::updateFailedAttempts($ip);
+                Blacklist::updateFailedAttempts($ip);
                 $error = 'Invalid username or password.';
                 ErrorManager::getInstance()->log($error);
                 MessageHelper::addMessage($error);

--- a/update-api/app/Controllers/HomeController.php
+++ b/update-api/app/Controllers/HomeController.php
@@ -14,7 +14,7 @@
 
 namespace App\Controllers;
 
-use App\Core\Utility;
+use App\Helpers\Validation;
 use App\Core\ErrorManager;
 use App\Core\Controller;
 use App\Models\HostsModel;
@@ -36,10 +36,10 @@ class HomeController extends Controller
                 isset($_POST['csrf_token'], $_SESSION['csrf_token']) &&
                 hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])
             ) {
-                $domain = isset($_POST['domain']) ? Utility::validateDomain($_POST['domain']) : null;
+                $domain = isset($_POST['domain']) ? Validation::validateDomain($_POST['domain']) : null;
                 $id = isset($_POST['id']) ? filter_var($_POST['id'], FILTER_VALIDATE_INT) : null;
                 if (isset($_POST['add_entry'])) {
-                    $newKey = Utility::generateKey();
+                    $newKey = Validation::generateKey();
                     if ($domain !== null && HostsModel::addEntry($domain, $newKey)) {
                         MessageHelper::addMessage('Entry added successfully.');
                     } else {
@@ -48,7 +48,7 @@ class HomeController extends Controller
                         MessageHelper::addMessage($error);
                     }
                 } elseif (isset($_POST['regen_entry'])) {
-                    $newKey = Utility::generateKey();
+                    $newKey = Validation::generateKey();
                     if ($id !== null && $domain !== null && HostsModel::updateEntry($id, $domain, $newKey)) {
                         MessageHelper::addMessage('Key regenerated successfully.');
                     } else {
@@ -144,7 +144,7 @@ class HomeController extends Controller
                 $fields = explode(' ', $entry);
                 $domain = isset($fields[0]) ? $fields[0] : '';
                 $encryptedKey = $fields[1] ?? '';
-                $key = Utility::decrypt($encryptedKey) ?? '';
+                $key = Validation::decrypt($encryptedKey) ?? '';
                 $hostsTableHtml .= self::generateHostsTableRow($lineNumber, $domain, $key);
             }
 
@@ -166,7 +166,7 @@ class HomeController extends Controller
                 $fields = explode(' ', $entry);
                 $domain = isset($fields[0]) ? $fields[0] : '';
                 $encryptedKey = $fields[1] ?? '';
-                $key = Utility::decrypt($encryptedKey) ?? '';
+                $key = Validation::decrypt($encryptedKey) ?? '';
                 $hostsTableHtml .= self::generateHostsTableRow($lineNumber, $domain, $key);
             }
 

--- a/update-api/app/Controllers/PluginsController.php
+++ b/update-api/app/Controllers/PluginsController.php
@@ -14,7 +14,7 @@
 
 namespace App\Controllers;
 
-use App\Core\Utility;
+use App\Helpers\Validation;
 use App\Core\ErrorManager;
 use App\Core\Controller;
 use App\Models\PluginModel;
@@ -51,7 +51,7 @@ class PluginsController extends Controller
                     exit();
                 } elseif (isset($_POST['delete_plugin'])) {
                     $plugin_name = isset($_POST['plugin_name'])
-                        ? Utility::validateSlug($_POST['plugin_name'])
+                        ? Validation::validateSlug($_POST['plugin_name'])
                         : null;
                     if ($plugin_name !== null && PluginModel::deletePlugin($plugin_name)) {
                         MessageHelper::addMessage('Plugin deleted successfully!');

--- a/update-api/app/Controllers/ThemesController.php
+++ b/update-api/app/Controllers/ThemesController.php
@@ -14,7 +14,7 @@
 
 namespace App\Controllers;
 
-use App\Core\Utility;
+use App\Helpers\Validation;
 use App\Core\ErrorManager;
 use App\Core\Controller;
 use App\Models\ThemeModel;
@@ -50,7 +50,7 @@ class ThemesController extends Controller
                     header('Location: /thupdate');
                     exit();
                 } elseif (isset($_POST['delete_theme'])) {
-                    $theme_name = isset($_POST['theme_name']) ? Utility::validateSlug($_POST['theme_name']) : null;
+                    $theme_name = isset($_POST['theme_name']) ? Validation::validateSlug($_POST['theme_name']) : null;
                     if ($theme_name !== null && ThemeModel::deleteTheme($theme_name)) {
                         MessageHelper::addMessage('Theme deleted successfully!');
                     } else {

--- a/update-api/app/Core/AuthMiddleware.php
+++ b/update-api/app/Core/AuthMiddleware.php
@@ -14,7 +14,7 @@
 
 namespace App\Core;
 
-use App\Core\Utility;
+use App\Models\Blacklist;
 use App\Core\ErrorManager;
 
 class AuthMiddleware
@@ -22,7 +22,7 @@ class AuthMiddleware
     public static function check(): void
     {
         $ip = filter_var($_SERVER['REMOTE_ADDR'] ?? '', FILTER_VALIDATE_IP);
-        if ($ip && Utility::isBlacklisted($ip)) {
+        if ($ip && Blacklist::isBlacklisted($ip)) {
             http_response_code(403);
             ErrorManager::getInstance()->log("Blacklisted IP attempted access: $ip", 'error');
             exit();

--- a/update-api/app/Helpers/Validation.php
+++ b/update-api/app/Helpers/Validation.php
@@ -8,13 +8,13 @@
  * Link:    https://vontainment.com
  * Version: 3.0.0
  *
- * File: Utility.php
+ * File: Validation.php
  * Description: WordPress Update API
  */
 
-namespace App\Core;
+namespace App\Helpers;
 
-class Utility
+class Validation
 {
     /**
      * Validate a domain string.
@@ -121,8 +121,8 @@ class Utility
     /**
      * Encrypt a string using AES-256-CBC.
      *
-     * @param string $plain Plain text to encrypt.
-     * @return string Base64-encoded cipher text.
+     * @param string $plain Text to encrypt.
+     * @return string Base64-encoded encrypted string.
      */
     public static function encrypt(string $plain): string
     {
@@ -159,96 +159,5 @@ class Utility
             $iv
         );
         return $plain === false ? null : $plain;
-    }
-
-    /**
-     * Update the number of failed login attempts for an IP address and blacklist if necessary.
-     *
-     * @param string $ip The IP address to update.
-     * @return void
-     */
-    public static function updateFailedAttempts(string $ip): void
-    {
-        $blacklist_file = BLACKLIST_DIR . "/BLACKLIST.json";
-        $content = [];
-        if (file_exists($blacklist_file)) {
-            $raw = @file_get_contents($blacklist_file);
-            if ($raw !== false) {
-                $json = json_decode($raw, true);
-                if (is_array($json)) {
-                    $content = $json;
-                }
-            }
-        }
-
-        if (isset($content[$ip])) {
-            $content[$ip]['login_attempts'] += 1;
-            if ($content[$ip]['login_attempts'] >= 3) {
-                $content[$ip]['blacklisted'] = true;
-                $content[$ip]['timestamp'] = time();
-            }
-        } else {
-            $content[$ip] = [
-                             'login_attempts' => 1,
-                             'blacklisted'    => false,
-                             'timestamp'      => time(),
-                            ];
-        }
-
-        $fp = fopen($blacklist_file, 'c+');
-        if ($fp) {
-            if (flock($fp, LOCK_EX)) {
-                ftruncate($fp, 0);
-                rewind($fp);
-                fwrite($fp, json_encode($content));
-                fflush($fp);
-                flock($fp, LOCK_UN);
-            }
-            fclose($fp);
-        }
-    }
-
-    /**
-     * Check if an IP address is blacklisted. If the blacklist has expired, reset blacklist and login attempts.
-     *
-     * @param string $ip The IP address to check.
-     * @return bool True if the IP is blacklisted, false otherwise.
-     */
-    public static function isBlacklisted(string $ip): bool
-    {
-        $blacklist_file = BLACKLIST_DIR . "/BLACKLIST.json";
-        $blacklist = [];
-        if (file_exists($blacklist_file)) {
-            $raw = @file_get_contents($blacklist_file);
-            if ($raw !== false) {
-                $json = json_decode($raw, true);
-                if (is_array($json)) {
-                    $blacklist = $json;
-                }
-            }
-        }
-
-        if (isset($blacklist[$ip]) && $blacklist[$ip]['blacklisted']) {
-            // Check if the timestamp is older than three days
-            if (time() - $blacklist[$ip]['timestamp'] > (3 * 24 * 60 * 60)) {
-                // Remove the IP address from the blacklist and reset login_attempts
-                $blacklist[$ip]['blacklisted'] = false;
-                $blacklist[$ip]['login_attempts'] = 0;
-                $fp = fopen($blacklist_file, 'c+');
-                if ($fp) {
-                    if (flock($fp, LOCK_EX)) {
-                        ftruncate($fp, 0);
-                        rewind($fp);
-                        fwrite($fp, json_encode($blacklist));
-                        fflush($fp);
-                        flock($fp, LOCK_UN);
-                    }
-                    fclose($fp);
-                }
-            } else {
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/update-api/app/Models/Blacklist.php
+++ b/update-api/app/Models/Blacklist.php
@@ -1,0 +1,109 @@
+<?php
+// phpcs:ignoreFile PSR1.Files.SideEffects.FoundWithSymbols
+
+/**
+ * Project: UpdateAPI
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
+ *
+ * File: Blacklist.php
+ * Description: WordPress Update API
+ */
+
+namespace App\Models;
+
+class Blacklist
+{
+    /**
+     * Update the number of failed login attempts for an IP address and blacklist if necessary.
+     *
+     * @param string $ip The IP address to update.
+     * @return void
+     */
+    public static function updateFailedAttempts(string $ip): void
+    {
+        $blacklist_file = BLACKLIST_DIR . "/BLACKLIST.json";
+        $content = [];
+        if (file_exists($blacklist_file)) {
+            $raw = @file_get_contents($blacklist_file);
+            if ($raw !== false) {
+                $json = json_decode($raw, true);
+                if (is_array($json)) {
+                    $content = $json;
+                }
+            }
+        }
+
+        if (isset($content[$ip])) {
+            $content[$ip]['login_attempts'] += 1;
+            if ($content[$ip]['login_attempts'] >= 3) {
+                $content[$ip]['blacklisted'] = true;
+                $content[$ip]['timestamp'] = time();
+            }
+        } else {
+            $content[$ip] = [
+                             'login_attempts' => 1,
+                             'blacklisted'    => false,
+                             'timestamp'      => time(),
+                            ];
+        }
+
+        $fp = fopen($blacklist_file, 'c+');
+        if ($fp) {
+            if (flock($fp, LOCK_EX)) {
+                ftruncate($fp, 0);
+                rewind($fp);
+                fwrite($fp, json_encode($content));
+                fflush($fp);
+                flock($fp, LOCK_UN);
+            }
+            fclose($fp);
+        }
+    }
+
+    /**
+     * Check if an IP address is blacklisted. If the blacklist has expired, reset blacklist and login attempts.
+     *
+     * @param string $ip The IP address to check.
+     * @return bool True if the IP is blacklisted, false otherwise.
+     */
+    public static function isBlacklisted(string $ip): bool
+    {
+        $blacklist_file = BLACKLIST_DIR . "/BLACKLIST.json";
+        $blacklist = [];
+        if (file_exists($blacklist_file)) {
+            $raw = @file_get_contents($blacklist_file);
+            if ($raw !== false) {
+                $json = json_decode($raw, true);
+                if (is_array($json)) {
+                    $blacklist = $json;
+                }
+            }
+        }
+
+        if (isset($blacklist[$ip]) && $blacklist[$ip]['blacklisted']) {
+            // Check if the timestamp is older than three days
+            if (time() - $blacklist[$ip]['timestamp'] > (3 * 24 * 60 * 60)) {
+                // Remove the IP address from the blacklist and reset login_attempts
+                $blacklist[$ip]['blacklisted'] = false;
+                $blacklist[$ip]['login_attempts'] = 0;
+                $fp = fopen($blacklist_file, 'c+');
+                if ($fp) {
+                    if (flock($fp, LOCK_EX)) {
+                        ftruncate($fp, 0);
+                        rewind($fp);
+                        fwrite($fp, json_encode($blacklist));
+                        fflush($fp);
+                        flock($fp, LOCK_UN);
+                    }
+                    fclose($fp);
+                }
+            } else {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/update-api/app/Models/HostsModel.php
+++ b/update-api/app/Models/HostsModel.php
@@ -14,7 +14,7 @@
 
 namespace App\Models;
 
-use App\Core\Utility;
+use App\Helpers\Validation;
 
 class HostsModel
 {
@@ -42,7 +42,7 @@ class HostsModel
     {
         $safe_domain = htmlspecialchars($domain, ENT_QUOTES, 'UTF-8');
         $safe_key = htmlspecialchars($key, ENT_QUOTES, 'UTF-8');
-        $new_entry = $safe_domain . ' ' . Utility::encrypt($safe_key);
+        $new_entry = $safe_domain . ' ' . Validation::encrypt($safe_key);
         return file_put_contents(self::$file, $new_entry . "\n", FILE_APPEND | LOCK_EX) !== false;
     }
 
@@ -60,7 +60,7 @@ class HostsModel
         $entries = self::getEntries();
         $safe_domain = htmlspecialchars($domain, ENT_QUOTES, 'UTF-8');
         $safe_key = htmlspecialchars($key, ENT_QUOTES, 'UTF-8');
-        $entries[$line] = $safe_domain . ' ' . Utility::encrypt($safe_key);
+        $entries[$line] = $safe_domain . ' ' . Validation::encrypt($safe_key);
         return file_put_contents(self::$file, implode("\n", $entries) . "\n") !== false;
     }
 

--- a/update-api/app/Models/PluginModel.php
+++ b/update-api/app/Models/PluginModel.php
@@ -14,7 +14,7 @@
 
 namespace App\Models;
 
-use App\Core\Utility;
+use App\Helpers\Validation;
 
 class PluginModel
 {
@@ -66,7 +66,7 @@ class PluginModel
         $total_files = count($fileArray['name']);
 
         for ($i = 0; $i < $total_files; $i++) {
-            $file_name = isset($fileArray['name'][$i]) ? Utility::validateFilename($fileArray['name'][$i]) : '';
+            $file_name = isset($fileArray['name'][$i]) ? Validation::validateFilename($fileArray['name'][$i]) : '';
             $file_tmp = isset($fileArray['tmp_name'][$i]) ? $fileArray['tmp_name'][$i] : '';
             $file_error = isset($fileArray['error'][$i]) ? filter_var($fileArray['error'][$i], FILTER_VALIDATE_INT) : UPLOAD_ERR_NO_FILE;
             $file_extension = strtolower(pathinfo($file_name, PATHINFO_EXTENSION));

--- a/update-api/app/Models/ThemeModel.php
+++ b/update-api/app/Models/ThemeModel.php
@@ -14,7 +14,7 @@
 
 namespace App\Models;
 
-use App\Core\Utility;
+use App\Helpers\Validation;
 
 class ThemeModel
 {
@@ -67,7 +67,7 @@ class ThemeModel
 
         for ($i = 0; $i < $total_files; $i++) {
             $file_name = isset($fileArray['name'][$i])
-                ? Utility::validateFilename($fileArray['name'][$i])
+                ? Validation::validateFilename($fileArray['name'][$i])
                 : '';
             $file_tmp = isset($fileArray['tmp_name'][$i])
                 ? $fileArray['tmp_name'][$i]


### PR DESCRIPTION
## Summary
- extract validation and encryption helpers into `App\Helpers\Validation`
- move IP blacklist logic to `App\Models\Blacklist`
- update controllers and models to use the new helpers and remove `App\Core\Utility`
- document new classes and add changelog entry

## Testing
- `php -l update-api/app/Helpers/Validation.php && php -l update-api/app/Models/Blacklist.php && php -l update-api/app/Core/AuthMiddleware.php && php -l update-api/app/Controllers/PluginsController.php && php -l update-api/app/Controllers/HomeController.php && php -l update-api/app/Models/PluginModel.php && php -l update-api/app/Controllers/AuthController.php && php -l update-api/app/Models/HostsModel.php && php -l update-api/app/Controllers/ThemesController.php && php -l update-api/app/Models/ThemeModel.php && php -l update-api/app/Controllers/ApiController.php`

------
https://chatgpt.com/codex/tasks/task_e_689d0f2d3858832aafdcfd80c7470911