### PR TITLE
Refine router dispatch and API auth handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 - Switched router to instantiate controllers, dropped unused account/user/info routes, and added `/api` endpoint.
 - Updated `LoginController` to render views through `$this` instead of creating a new instance.
 - Converted controllers to instance methods using `$this->render` and removed the feeds controller and route.
+ - Refined router dispatch to include HTTP method and validate API requests before enforcing authentication.

--- a/update-api/public/index.php
+++ b/update-api/public/index.php
@@ -25,5 +25,5 @@ $session->regenerate();
 
 ErrorManager::handle(function (): void {
     $router = new Router();
-    $router->dispatch($_SERVER['REQUEST_URI']);
+    $router->dispatch($_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI']);
 });


### PR DESCRIPTION
## Summary
- Adjust router dispatch to accept HTTP method and differentiate API routes using required query parameters before enforcing authentication
- Update public index to pass request method and URI to router dispatch
- Document router dispatch changes in changelog

## Testing
- `composer test` *(fails: Command "test" is not defined)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `../vendor/bin/phpcs --report=summary app/Core/Router.php public/index.php`


------
https://chatgpt.com/codex/tasks/task_e_689d23f4e780832a8c9ef9e49e01b9ad