### PR TITLE
Refactor Router into singleton and document root redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 - Converted controllers to instance methods using `$this->render` and removed the feeds controller and route.
 - Refined router dispatch to include HTTP method and validate API requests before enforcing authentication.
 - Streamlined session validation to check only timeout and user agent, moved IP blacklist enforcement to authentication, and added unit tests for session expiry, user-agent changes, and blacklist handling.
+- Refactored router into a singleton and documented root URL redirection to `/home`.

--- a/update-api/app/Core/Router.php
+++ b/update-api/app/Core/Router.php
@@ -21,11 +21,17 @@ use App\Core\SessionManager;
 
 class Router
 {
+    private static ?Router $instance = null;
     private Dispatcher $dispatcher;
 
-    public function __construct()
+    private function __construct()
     {
         $this->dispatcher = simpleDispatcher(function (RouteCollector $r): void {
+            // Redirect the root URL to the home page for convenience
+            $r->addRoute('GET', '/', function (): void {
+                header('Location: /home');
+                exit();
+            });
             $r->addRoute('GET', '/login', ['\\App\\Controllers\\LoginController', 'handleRequest']);
             $r->addRoute('POST', '/login', ['\\App\\Controllers\\LoginController', 'handleSubmission']);
             $r->addRoute('GET', '/home', ['\\App\\Controllers\\HomeController', 'handleRequest']);
@@ -37,11 +43,19 @@ class Router
             $r->addRoute('GET', '/logs', ['\\App\\Controllers\\LogsController', 'handleRequest']);
             $r->addRoute('POST', '/logs', ['\\App\\Controllers\\LogsController', 'handleSubmission']);
             $r->addRoute('GET', '/api', ['\\App\\Controllers\\ApiController', 'handleRequest']);
-            $r->addRoute('GET', '/', function (): void {
-                header('Location: /home');
-                exit();
-            });
         });
+    }
+
+    /**
+     * Returns the shared Router instance.
+     */
+    public static function getInstance(): Router
+    {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
     }
 
     public function dispatch(string $method, string $uri): void

--- a/update-api/public/index.php
+++ b/update-api/public/index.php
@@ -24,6 +24,6 @@ $session->start();
 $session->regenerate();
 
 ErrorManager::handle(function (): void {
-    $router = new Router();
+    $router = Router::getInstance();
     $router->dispatch($_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI']);
 });

--- a/update-api/tests/RouterTest.php
+++ b/update-api/tests/RouterTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use App\Core\Router;
+
+class RouterTest extends TestCase
+{
+    public function testGetInstanceReturnsSameRouter(): void
+    {
+        $instance1 = Router::getInstance();
+        $instance2 = Router::getInstance();
+        $this->assertSame($instance1, $instance2);
+    }
+}


### PR DESCRIPTION
## Summary
- Convert router into a singleton and document root redirect to `/home`
- Update index to use the singleton router
- Add RouterTest verifying singleton instance

## Testing
- `vendor/bin/phpcs --standard=update-api/phpcs.xml update-api/app/Core/Router.php update-api/public/index.php update-api/tests/RouterTest.php`
- `cd update-api && vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_689d273955d4832abe1c53043724b880