### PR TITLE
Resolve PHPStan issues and add type annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 - Streamlined session validation to check only timeout and user agent, moved IP blacklist enforcement to authentication, and added unit tests for session expiry, user-agent changes, and blacklist handling.
 - Refactored router into a singleton and documented root URL redirection to `/home`.
 - Restricted table generation helpers in controllers and `SessionManager::isValid` to internal use and updated tests accordingly.
+- Fixed PHPStan reported issues by initializing variables, adding explicit type annotations, and excluding vendor code from analysis.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,6 +3,9 @@ parameters:
   paths:
     - mu-plugin
     - update-api
+  excludePaths:
+    - update-api/vendor
+    - update-api/vendor/*
   bootstrapFiles:
     - .github\phpstan-bootstrap.php
 

--- a/update-api/app/Controllers/ApiController.php
+++ b/update-api/app/Controllers/ApiController.php
@@ -76,8 +76,8 @@ class ApiController extends Controller
         if ($type === 'theme') {
             $dir = THEMES_DIR;
             $log = LOG_DIR . '/theme.log';
-        }
-        if ($type === 'plugin') {
+        } else {
+            // Fallback to plugins directory; $type is validated earlier.
             $dir = PLUGINS_DIR;
             $log = LOG_DIR . '/plugin.log';
         }

--- a/update-api/app/Controllers/HomeController.php
+++ b/update-api/app/Controllers/HomeController.php
@@ -85,7 +85,7 @@ class HomeController extends Controller
     {
         return '<tr>
             <form method="post" action="/home">
-                <input type="hidden" name="id" value="' . htmlspecialchars($lineNumber, ENT_QUOTES, 'UTF-8') . '">
+                <input type="hidden" name="id" value="' . htmlspecialchars((string)$lineNumber, ENT_QUOTES, 'UTF-8') . '">
                 <input type="hidden" name="csrf_token" value="' .
                     htmlspecialchars(SessionManager::getInstance()->get('csrf_token') ?? '', ENT_QUOTES, 'UTF-8') . '">
                 <td><input class="hosts-domain" type="text" name="domain" value="' .
@@ -112,7 +112,7 @@ class HomeController extends Controller
         $entries = HostsModel::getEntries();
         $hostsTableHtml = '';
         if (count($entries) > 0) {
-            $halfCount = ceil(count($entries) / 2);
+            $halfCount = (int) ceil(count($entries) / 2);
             $entriesColumn1 = array_slice($entries, 0, $halfCount);
             $entriesColumn2 = array_slice($entries, $halfCount);
             $hostsTableHtml .= '<div class="row">';

--- a/update-api/app/Controllers/PluginsController.php
+++ b/update-api/app/Controllers/PluginsController.php
@@ -112,7 +112,7 @@ class PluginsController extends Controller
     {
         $plugins = PluginModel::getPlugins();
         if (count($plugins) > 0) {
-            $halfCount = ceil(count($plugins) / 2);
+            $halfCount = (int) ceil(count($plugins) / 2);
             $pluginsColumn1 = array_slice($plugins, 0, $halfCount);
             $pluginsColumn2 = array_slice($plugins, $halfCount);
             $pluginsTableHtml = '<div class="row"><div class="column">

--- a/update-api/app/Controllers/ThemesController.php
+++ b/update-api/app/Controllers/ThemesController.php
@@ -110,7 +110,7 @@ class ThemesController extends Controller
     {
         $themes = ThemeModel::getThemes();
         if (count($themes) > 0) {
-            $half_count = ceil(count($themes) / 2);
+            $half_count = (int) ceil(count($themes) / 2);
             $themes_column1 = array_slice($themes, 0, $half_count);
             $themes_column2 = array_slice($themes, $half_count);
             $themesTableHtml = '<div class="row"><div class="column">

--- a/update-api/app/Core/Controller.php
+++ b/update-api/app/Core/Controller.php
@@ -16,6 +16,11 @@ namespace App\Core;
 
 class Controller
 {
+    /**
+     * Render a view and pass data to it.
+     *
+     * @param array<string, mixed> $data
+     */
     protected function render(string $view, array $data = []): void
     {
         extract($data);

--- a/update-api/app/Helpers/MessageHelper.php
+++ b/update-api/app/Helpers/MessageHelper.php
@@ -21,7 +21,10 @@ class MessageHelper
     public static function addMessage(string $message): void
     {
         $session = SessionManager::getInstance();
-        $messages = $session->get('messages', []);
+        $messages = $session->get('messages');
+        if (!is_array($messages)) {
+            $messages = [];
+        }
         $messages[] = $message;
         $session->set('messages', $messages);
     }
@@ -29,8 +32,8 @@ class MessageHelper
     public static function displayAndClearMessages(): void
     {
         $session = SessionManager::getInstance();
-        $messages = $session->get('messages', []);
-        if (!empty($messages)) {
+        $messages = $session->get('messages');
+        if (is_array($messages) && !empty($messages)) {
             foreach ($messages as $message) {
                 echo '<script>showToast(' . json_encode($message) . ');</script>';
             }

--- a/update-api/app/Models/HostsModel.php
+++ b/update-api/app/Models/HostsModel.php
@@ -24,7 +24,7 @@ class HostsModel
     /**
      * Return all host file entries as array of lines.
      *
-     * @return array
+     * @return array<int, string>
      */
     public static function getEntries(): array
     {

--- a/update-api/app/Models/PluginModel.php
+++ b/update-api/app/Models/PluginModel.php
@@ -23,7 +23,7 @@ class PluginModel
     /**
      * Return array of plugin file paths.
      *
-     * @return array
+     * @return array<int, string>
      */
     public static function getPlugins(): array
     {
@@ -54,10 +54,10 @@ class PluginModel
     /**
      * Upload plugin files.
      *
-     * @param array $fileArray $_FILES['plugin_file'] array structure
-     * @param bool  $isAjax    Whether the request was via AJAX
+     * @param array<string, array<int, mixed>> $fileArray $_FILES['plugin_file'] structure
+     * @param bool                              $isAjax    Whether the request was via AJAX
      *
-     * @return array Array of status messages
+     * @return string[] Array of status messages
      */
     public static function uploadFiles(array $fileArray, bool $isAjax = false): array
     {

--- a/update-api/app/Models/ThemeModel.php
+++ b/update-api/app/Models/ThemeModel.php
@@ -23,7 +23,7 @@ class ThemeModel
     /**
      * Return array of theme file paths.
      *
-     * @return array
+     * @return array<int, string>
      */
     public static function getThemes(): array
     {
@@ -54,10 +54,10 @@ class ThemeModel
     /**
      * Upload theme files.
      *
-     * @param array $fileArray $_FILES['theme_file'] array structure
-     * @param bool  $isAjax    Whether the request was via AJAX
+     * @param array<string, array<int, mixed>> $fileArray $_FILES['theme_file'] structure
+     * @param bool                              $isAjax    Whether the request was via AJAX
      *
-     * @return array Array of status messages
+     * @return string[] Array of status messages
      */
     public static function uploadFiles(array $fileArray, bool $isAjax = false): array
     {

--- a/update-api/app/Views/home.php
+++ b/update-api/app/Views/home.php
@@ -14,6 +14,9 @@
 
 require_once __DIR__ . '/layouts/header.php';
 
+/** @var string $hostsTableHtml */
+$hostsTableHtml = $hostsTableHtml ?? '';
+
 ?>
 
 <div class="content-box">

--- a/update-api/app/Views/logs.php
+++ b/update-api/app/Views/logs.php
@@ -17,9 +17,17 @@ require_once __DIR__ . '/layouts/header.php';
 ?>
 <div class="content-box">
     <h2>Plugin Log</h2>
-    <?php echo $ploutput; ?>
+    <?php
+    /** @var string $ploutput */
+    $ploutput = $ploutput ?? '';
+    echo $ploutput;
+    ?>
     <h2>Theme Log</h2>
-    <?php echo $thoutput; ?>
+    <?php
+    /** @var string $thoutput */
+    $thoutput = $thoutput ?? '';
+    echo $thoutput;
+    ?>
     <form method="post" action="/logs" style="margin-top:20px;">
         <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(App\Core\SessionManager::getInstance()->get('csrf_token') ?? '', ENT_QUOTES, 'UTF-8'); ?>">
         <button class="red-button" type="submit" name="clear_logs">Clear Logs</button>

--- a/update-api/app/Views/plupdate.php
+++ b/update-api/app/Views/plupdate.php
@@ -18,7 +18,11 @@ require_once __DIR__ . '/layouts/header.php';
 <div class="content-box">
   <h2>Plugins</h2>
   <div id="plugins_table">
-    <?php echo $pluginsTableHtml; ?>
+    <?php
+    /** @var string $pluginsTableHtml */
+    $pluginsTableHtml = $pluginsTableHtml ?? '';
+    echo $pluginsTableHtml;
+    ?>
   </div>
   <div class="plupload section">
     <div id="upload-container">

--- a/update-api/app/Views/thupdate.php
+++ b/update-api/app/Views/thupdate.php
@@ -18,7 +18,11 @@ require_once __DIR__ . '/layouts/header.php';
 <div class="content-box">
   <h2>Themes</h2>
   <div id="themes_table">
-    <?php echo $themesTableHtml; ?>
+    <?php
+    /** @var string $themesTableHtml */
+    $themesTableHtml = $themesTableHtml ?? '';
+    echo $themesTableHtml;
+    ?>
   </div>
   <div class="plupload section">
     <div id="upload-container">


### PR DESCRIPTION
## Summary
- ensure directories and logs are initialized in API controller
- cast array slice parameters and sanitize IDs in controllers
- annotate data types and fix session message helper
- exclude vendor directory from PHPStan

## Testing
- `php vendor/bin/phpcs update-api/app` (warning: deprecated sniffs)
- `php phpunit.phar --bootstrap update-api/vendor/autoload.php tests` (fail: missing storage file & session tests)
- `php vendor/bin/phpstan analyse` (error: Some parallel worker jobs have not finished)


------
https://chatgpt.com/codex/tasks/task_e_689d684384ac832aa8ab6b778b3fa4a0