### PR TITLE
feat: replace json blacklist with sqlite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+## Unreleased
+### Changed
+- Replace JSON-based blacklist storage with SQLite database table `blacklist`.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The v-wordpress-plugin-updater project is designed to streamline the management 
 | 🧪 | **Testing**           | <ul><li>Limited unit tests present, primarily for core classes</li><li>Uses PHPUnit for testing PHP components</li><li>Test coverage appears minimal, mainly functional tests</li></ul> |
 | ⚡️  | **Performance**       | <ul><li>Optimized file checks with caching mechanisms</li><li>Minimized HTTP requests during update checks</li><li>Uses transient caching in WordPress</li></ul> |
 | 🛡️ | **Security**          | <ul><li>Sanitizes and validates external inputs</li><li>Uses nonces for admin actions</li><li>Reads configuration files with restricted permissions</li></ul> |
-| 📦 | **Dependencies**      | <ul><li>PHP standard library</li><li>WordPress core functions</li><li>Configuration files: robots.txt, blacklist.json, php.ini, etc.</li></ul> |
+| 📦 | **Dependencies**      | <ul><li>PHP standard library</li><li>WordPress core functions</li><li>Configuration files: robots.txt, database.sqlite, php.ini, etc.</li></ul> |
 
 ---
 
@@ -123,7 +123,7 @@ The v-wordpress-plugin-updater project is designed to streamline the management 
     │   │   ├── index.php
     │   │   └── robots.txt
     │   └── storage
-    │       ├── BLACKLIST.json
+    │       ├── database.sqlite
     │       └── logs
     │           ├── php_app.log
     │           ├── plugin.log
@@ -406,10 +406,10 @@ The v-wordpress-plugin-updater project is designed to streamline the management 
 							<th style='text-align: left; padding: 8px;'>Summary</th>
 						</tr>
 					</thead>
-						<tr style='border-bottom: 1px solid #eee;'>
-							<td style='padding: 8px;'><b><a href='https://github.com/djav1985/v-wordpress-plugin-updater/blob/master/update-api/storage/BLACKLIST.json'>BLACKLIST.json</a></b></td>
-							<td style='padding: 8px;'>- Maintains a list of blacklisted entries to enforce security and access control within the update API<br>- Serves as a centralized reference for filtering or blocking specific data, ensuring compliance with security policies across the system<br>- Integrates seamlessly into the overall architecture to support consistent and efficient management of restricted entities.</td>
-						</tr>
+                                                <tr style='border-bottom: 1px solid #eee;'>
+                                                        <td style='padding: 8px;'><b><a href='https://github.com/djav1985/v-wordpress-plugin-updater/blob/master/update-api/storage/database.sqlite'>database.sqlite</a></b></td>
+                                                        <td style='padding: 8px;'>- Stores blacklist records in a SQLite table for tracking failed login attempts<br>- Ensures consistent enforcement of access controls without relying on flat files<br>- Automatically created and maintained by the application.</td>
+                                                </tr>
 					</table>
 				</blockquote>
 			</details>

--- a/mu-plugin/v-sys-plugin-updater-mu.php
+++ b/mu-plugin/v-sys-plugin-updater-mu.php
@@ -18,98 +18,96 @@
  * @package VontainmentPluginUpdaterMU
 */
 
-if (! defined('ABSPATH')) {
-    exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
 // Schedule the update check to run every day.
-add_action('wp', 'vontmnt_plugin_updater_schedule_updates');
+add_action( 'wp', 'vontmnt_plugin_updater_schedule_updates' );
 
 
-/** 
+/**
  * @package UpdateAPI
  * @author  Vontainment <services@vontainment.com>
  * @license https://opensource.org/licenses/MIT MIT License
  * @link    https://vontainment.com
  *
  * Schedule daily plugin update checks for multisite. */
-function vontmnt_plugin_updater_schedule_updates(): void
-{
-    if (! is_main_site()) {
-        return;
-    }
-    if (! wp_next_scheduled('vontmnt_plugin_updater_check_updates')) {
-        wp_schedule_event(time(), 'daily', 'vontmnt_plugin_updater_check_updates');
-    }
+function vontmnt_plugin_updater_schedule_updates(): void {
+	if ( ! is_main_site() ) {
+		return;
+	}
+	if ( ! wp_next_scheduled( 'vontmnt_plugin_updater_check_updates' ) ) {
+		wp_schedule_event( time(), 'daily', 'vontmnt_plugin_updater_check_updates' );
+	}
 }
 
-add_action('vontmnt_plugin_updater_check_updates', 'vontmnt_plugin_updater_run_updates');
+add_action( 'vontmnt_plugin_updater_check_updates', 'vontmnt_plugin_updater_run_updates' );
 
-/** 
+/**
  * @package UpdateAPI
  * @author  Vontainment <services@vontainment.com>
  * @license https://opensource.org/licenses/MIT MIT License
  * @link    https://vontainment.com
  *
  * Run plugin updates for all installed plugins on the main site. */
-function vontmnt_plugin_updater_run_updates(): void
-{
-    // Check if it's the main site.
-    if (! is_main_site()) {
-        return;
-    }
-    if (! function_exists('get_plugins')) {
-        require_once ABSPATH . 'wp-admin/includes/plugin.php';
-    }
-    $plugins = get_plugins();
-    foreach ($plugins as $plugin_path => $plugin) {
-            $plugin_slug       = dirname($plugin_path);
-            $installed_version = $plugin['Version'];
-            $api_url           = add_query_arg(
-                array(
-                 'type'    => 'plugin',
-                 'domain'  => rawurlencode(wp_parse_url(site_url(), PHP_URL_HOST)),
-                 'slug'    => rawurlencode($plugin_slug),
-                 'version' => rawurlencode($installed_version),
-                 'key'     => VONTMENT_KEY,
-                ),
-                VONTMENT_PLUGINS
-            );
+function vontmnt_plugin_updater_run_updates(): void {
+	// Check if it's the main site.
+	if ( ! is_main_site() ) {
+		return;
+	}
+	if ( ! function_exists( 'get_plugins' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+	$plugins = get_plugins();
+	foreach ( $plugins as $plugin_path => $plugin ) {
+			$plugin_slug       = dirname( $plugin_path );
+			$installed_version = $plugin['Version'];
+			$api_url           = add_query_arg(
+				array(
+					'type'    => 'plugin',
+					'domain'  => rawurlencode( wp_parse_url( site_url(), PHP_URL_HOST ) ),
+					'slug'    => rawurlencode( $plugin_slug ),
+					'version' => rawurlencode( $installed_version ),
+					'key'     => VONTMENT_KEY,
+				),
+				VONTMENT_PLUGINS
+			);
 
-            // Use wp_remote_get instead of cURL.
-            $response      = wp_remote_get($api_url);
-            $http_code     = wp_remote_retrieve_response_code($response);
-            $response_body = wp_remote_retrieve_body($response);
+			// Use wp_remote_get instead of cURL.
+			$response      = wp_remote_get( $api_url );
+			$http_code     = wp_remote_retrieve_response_code( $response );
+			$response_body = wp_remote_retrieve_body( $response );
 
-        if (200 === $http_code && ! empty($response_body)) {
-            require_once ABSPATH . 'wp-admin/includes/file.php';
-            $upload_dir      = wp_upload_dir();
-            $plugin_zip_file = $upload_dir['path'] . '/' . basename($plugin_path) . '.zip';
-            file_put_contents($plugin_zip_file, $response_body);
+		if ( 200 === $http_code && ! empty( $response_body ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+			$upload_dir      = wp_upload_dir();
+			$plugin_zip_file = $upload_dir['path'] . '/' . basename( $plugin_path ) . '.zip';
+			file_put_contents( $plugin_zip_file, $response_body );
 
-            global $wp_filesystem;
-            if (empty($wp_filesystem)) {
-                    require_once ABSPATH . '/wp-admin/includes/file.php';
-                    WP_Filesystem();
-            }
+			global $wp_filesystem;
+			if ( empty( $wp_filesystem ) ) {
+					require_once ABSPATH . '/wp-admin/includes/file.php';
+					WP_Filesystem();
+			}
 
-            require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
-            $upgrader = new Plugin_Upgrader();
-            $callback = function ($options) use ($plugin_zip_file) {
-                            $options['package']           = $plugin_zip_file;
-                            $options['clear_destination'] = true;
-                            return $options;
-            };
-                add_filter('upgrader_package_options', $callback);
-                $upgrader->install($plugin_zip_file);
-                remove_filter('upgrader_package_options', $callback);
+			require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+			$upgrader = new Plugin_Upgrader();
+			$callback = function ( $options ) use ( $plugin_zip_file ) {
+							$options['package']           = $plugin_zip_file;
+							$options['clear_destination'] = true;
+							return $options;
+			};
+				add_filter( 'upgrader_package_options', $callback );
+				$upgrader->install( $plugin_zip_file );
+				remove_filter( 'upgrader_package_options', $callback );
 
-                // Delete the plugin zip file using wp_delete_file.
-                wp_delete_file($plugin_zip_file);
-        } elseif (204 === $http_code) {
-            continue;
-        } else {
-            break;
-        }
-    }
+				// Delete the plugin zip file using wp_delete_file.
+				wp_delete_file( $plugin_zip_file );
+		} elseif ( 204 === $http_code ) {
+			continue;
+		} else {
+			break;
+		}
+	}
 }

--- a/mu-plugin/v-sys-plugin-updater.php
+++ b/mu-plugin/v-sys-plugin-updater.php
@@ -18,91 +18,89 @@
  * @package VontainmentPluginUpdater
 */
 
-if (! defined('ABSPATH')) {
-    exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
-/** 
+/**
  * @package UpdateAPI
  * @author  Vontainment <services@vontainment.com>
  * @license https://opensource.org/licenses/MIT MIT License
  * @link    https://vontainment.com
  *
  * Schedule daily plugin update checks. */
-function vontmnt_plugin_updater_schedule_updates(): void
-{
-    if (! wp_next_scheduled('vontmnt_plugin_updater_check_updates')) {
-        wp_schedule_event(time(), 'daily', 'vontmnt_plugin_updater_check_updates');
-    }
+function vontmnt_plugin_updater_schedule_updates(): void {
+	if ( ! wp_next_scheduled( 'vontmnt_plugin_updater_check_updates' ) ) {
+		wp_schedule_event( time(), 'daily', 'vontmnt_plugin_updater_check_updates' );
+	}
 }
 
-add_action('wp', 'vontmnt_plugin_updater_schedule_updates');
+add_action( 'wp', 'vontmnt_plugin_updater_schedule_updates' );
 
-add_action('vontmnt_plugin_updater_check_updates', 'vontmnt_plugin_updater_run_updates');
+add_action( 'vontmnt_plugin_updater_check_updates', 'vontmnt_plugin_updater_run_updates' );
 
-/** 
+/**
  * @package UpdateAPI
  * @author  Vontainment <services@vontainment.com>
  * @license https://opensource.org/licenses/MIT MIT License
  * @link    https://vontainment.com
  *
  * Run plugin updates for all installed plugins. */
-function vontmnt_plugin_updater_run_updates(): void
-{
-    if (! function_exists('get_plugins')) {
-        require_once ABSPATH . 'wp-admin/includes/plugin.php';
-    }
-    $plugins = get_plugins();
-    foreach ($plugins as $plugin_path => $plugin) {
-        $plugin_slug       = dirname($plugin_path);
-        $installed_version = $plugin['Version'];
-        $api_url = add_query_arg(
-            array(
-             'type'    => 'plugin',
-             'domain'  => rawurlencode(wp_parse_url(site_url(), PHP_URL_HOST)),
-             'slug'    => rawurlencode($plugin_slug),
-             'version' => rawurlencode($installed_version),
-             'key'     => VONTMENT_KEY,
-            ),
-            VONTMENT_PLUGINS
-        );
+function vontmnt_plugin_updater_run_updates(): void {
+	if ( ! function_exists( 'get_plugins' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+	$plugins = get_plugins();
+	foreach ( $plugins as $plugin_path => $plugin ) {
+		$plugin_slug       = dirname( $plugin_path );
+		$installed_version = $plugin['Version'];
+		$api_url           = add_query_arg(
+			array(
+				'type'    => 'plugin',
+				'domain'  => rawurlencode( wp_parse_url( site_url(), PHP_URL_HOST ) ),
+				'slug'    => rawurlencode( $plugin_slug ),
+				'version' => rawurlencode( $installed_version ),
+				'key'     => VONTMENT_KEY,
+			),
+			VONTMENT_PLUGINS
+		);
 
-        // Use wp_remote_get instead of cURL.
-        $response      = wp_remote_get($api_url);
-        $http_code     = wp_remote_retrieve_response_code($response);
-        $response_body = wp_remote_retrieve_body($response);
+		// Use wp_remote_get instead of cURL.
+		$response      = wp_remote_get( $api_url );
+		$http_code     = wp_remote_retrieve_response_code( $response );
+		$response_body = wp_remote_retrieve_body( $response );
 
-        if ($http_code === 200 && ! empty($response_body)) {
-            require_once ABSPATH . 'wp-admin/includes/file.php';
-            $upload_dir      = wp_upload_dir();
-            $plugin_zip_file = $upload_dir['path'] . '/' . basename($plugin_path) . '.zip';
-            file_put_contents($plugin_zip_file, $response_body);
+		if ( $http_code === 200 && ! empty( $response_body ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+			$upload_dir      = wp_upload_dir();
+			$plugin_zip_file = $upload_dir['path'] . '/' . basename( $plugin_path ) . '.zip';
+			file_put_contents( $plugin_zip_file, $response_body );
 
-            global $wp_filesystem;
-            if (empty($wp_filesystem)) {
-                require_once ABSPATH . '/wp-admin/includes/file.php';
-                WP_Filesystem();
-            }
+			global $wp_filesystem;
+			if ( empty( $wp_filesystem ) ) {
+				require_once ABSPATH . '/wp-admin/includes/file.php';
+				WP_Filesystem();
+			}
 
-            require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
-            $upgrader = new Plugin_Upgrader();
-            $callback = function ($options) use ($plugin_zip_file) {
-                $options['package']           = $plugin_zip_file;
-                $options['clear_destination'] = true;
-                return $options;
-            };
-            add_filter('upgrader_package_options', $callback);
-            $upgrader->install($plugin_zip_file);
-            remove_filter('upgrader_package_options', $callback);
+			require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+			$upgrader = new Plugin_Upgrader();
+			$callback = function ( $options ) use ( $plugin_zip_file ) {
+				$options['package']           = $plugin_zip_file;
+				$options['clear_destination'] = true;
+				return $options;
+			};
+			add_filter( 'upgrader_package_options', $callback );
+			$upgrader->install( $plugin_zip_file );
+			remove_filter( 'upgrader_package_options', $callback );
 
-            // Delete the plugin zip file using wp_delete_file.
-            wp_delete_file($plugin_zip_file);
-        } elseif ($http_code === 204) {
-            // No updates, check next plugin.
-            continue;
-        } else {
-            // For 400, 403, or any other unexpected code, stop further processing.
-            break;
-        }
-    }
+			// Delete the plugin zip file using wp_delete_file.
+			wp_delete_file( $plugin_zip_file );
+		} elseif ( $http_code === 204 ) {
+			// No updates, check next plugin.
+			continue;
+		} else {
+			// For 400, 403, or any other unexpected code, stop further processing.
+			break;
+		}
+	}
 }

--- a/mu-plugin/v-sys-theme-updater-mu.php
+++ b/mu-plugin/v-sys-theme-updater-mu.php
@@ -18,12 +18,12 @@
  * @package VontainmentThemeUpdaterMU
 */
 
-if (! defined('ABSPATH')) {
-    exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
 // Schedule the update check to run every day on the main site.
-add_action('wp', 'vontmnt_theme_updater_schedule_updates');
+add_action( 'wp', 'vontmnt_theme_updater_schedule_updates' );
 
 /**
  * Schedule daily theme update checks for multisite.
@@ -33,17 +33,16 @@ add_action('wp', 'vontmnt_theme_updater_schedule_updates');
  * @license https://opensource.org/licenses/MIT MIT License
  * @link    https://vontainment.com
  */
-function vontmnt_theme_updater_schedule_updates(): void
-{
-    if (! is_main_site()) {
-        return;
-    }
-    if (! wp_next_scheduled('vontmnt_theme_updater_check_updates')) {
-        wp_schedule_event(time(), 'daily', 'vontmnt_theme_updater_check_updates');
-    }
+function vontmnt_theme_updater_schedule_updates(): void {
+	if ( ! is_main_site() ) {
+		return;
+	}
+	if ( ! wp_next_scheduled( 'vontmnt_theme_updater_check_updates' ) ) {
+		wp_schedule_event( time(), 'daily', 'vontmnt_theme_updater_check_updates' );
+	}
 }
 
-add_action('vontmnt_theme_updater_check_updates', 'vontmnt_theme_updater_run_updates');
+add_action( 'vontmnt_theme_updater_check_updates', 'vontmnt_theme_updater_run_updates' );
 
 /**
  * Run theme updates for all installed themes on the main site.
@@ -53,62 +52,61 @@ add_action('vontmnt_theme_updater_check_updates', 'vontmnt_theme_updater_run_upd
  * @license https://opensource.org/licenses/MIT MIT License
  * @link    https://vontainment.com
  */
-function vontmnt_theme_updater_run_updates(): void
-{
-    if (! is_main_site()) {
-        return;
-    }
-    if (! function_exists('wp_get_themes')) {
-        require_once ABSPATH . 'wp-includes/theme.php';
-    }
-    $themes = wp_get_themes();
-    foreach ($themes as $theme) {
-        $theme_slug        = $theme->get_stylesheet();
-        $installed_version = $theme->get('Version');
-        $api_url = add_query_arg(
-            array(
-             'type'    => 'theme',
-             'domain'  => rawurlencode(wp_parse_url(site_url(), PHP_URL_HOST)),
-             'slug'    => rawurlencode($theme_slug),
-             'version' => rawurlencode($installed_version),
-             'key'     => VONTMENT_KEY,
-            ),
-            VONTMENT_THEMES
-        );
+function vontmnt_theme_updater_run_updates(): void {
+	if ( ! is_main_site() ) {
+		return;
+	}
+	if ( ! function_exists( 'wp_get_themes' ) ) {
+		require_once ABSPATH . 'wp-includes/theme.php';
+	}
+	$themes = wp_get_themes();
+	foreach ( $themes as $theme ) {
+		$theme_slug        = $theme->get_stylesheet();
+		$installed_version = $theme->get( 'Version' );
+		$api_url           = add_query_arg(
+			array(
+				'type'    => 'theme',
+				'domain'  => rawurlencode( wp_parse_url( site_url(), PHP_URL_HOST ) ),
+				'slug'    => rawurlencode( $theme_slug ),
+				'version' => rawurlencode( $installed_version ),
+				'key'     => VONTMENT_KEY,
+			),
+			VONTMENT_THEMES
+		);
 
-        $response      = wp_remote_get($api_url);
-        $http_code     = wp_remote_retrieve_response_code($response);
-        $response_body = wp_remote_retrieve_body($response);
+		$response      = wp_remote_get( $api_url );
+		$http_code     = wp_remote_retrieve_response_code( $response );
+		$response_body = wp_remote_retrieve_body( $response );
 
-        if ($http_code === 200 && ! empty($response_body)) {
-            require_once ABSPATH . 'wp-admin/includes/file.php';
-            $upload_dir     = wp_upload_dir();
-            $theme_zip_file = $upload_dir['path'] . '/' . basename($theme_slug) . '.zip';
-            file_put_contents($theme_zip_file, $response_body);
+		if ( $http_code === 200 && ! empty( $response_body ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+			$upload_dir     = wp_upload_dir();
+			$theme_zip_file = $upload_dir['path'] . '/' . basename( $theme_slug ) . '.zip';
+			file_put_contents( $theme_zip_file, $response_body );
 
-            global $wp_filesystem;
-            if (empty($wp_filesystem)) {
-                require_once ABSPATH . '/wp-admin/includes/file.php';
-                WP_Filesystem();
-            }
+			global $wp_filesystem;
+			if ( empty( $wp_filesystem ) ) {
+				require_once ABSPATH . '/wp-admin/includes/file.php';
+				WP_Filesystem();
+			}
 
-            require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
-            $upgrader = new Theme_Upgrader();
-            $callback = function ($options) use ($theme_zip_file) {
-                $options['package']           = $theme_zip_file;
-                $options['clear_destination'] = true;
-                return $options;
-            };
-            add_filter('upgrader_package_options', $callback);
-            $upgrader->install($theme_zip_file);
-            remove_filter('upgrader_package_options', $callback);
+			require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+			$upgrader = new Theme_Upgrader();
+			$callback = function ( $options ) use ( $theme_zip_file ) {
+				$options['package']           = $theme_zip_file;
+				$options['clear_destination'] = true;
+				return $options;
+			};
+			add_filter( 'upgrader_package_options', $callback );
+			$upgrader->install( $theme_zip_file );
+			remove_filter( 'upgrader_package_options', $callback );
 
-            // Delete the theme zip file using wp_delete_file.
-            wp_delete_file($theme_zip_file);
-        } elseif ($http_code === 204) {
-            continue;
-        } else {
-            break;
-        }
-    }
+			// Delete the theme zip file using wp_delete_file.
+			wp_delete_file( $theme_zip_file );
+		} elseif ( $http_code === 204 ) {
+			continue;
+		} else {
+			break;
+		}
+	}
 }

--- a/mu-plugin/v-sys-theme-updater.php
+++ b/mu-plugin/v-sys-theme-updater.php
@@ -18,91 +18,89 @@
  * @package VontainmentThemeUpdater
 */
 
-if (! defined('ABSPATH')) {
-    exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
 
-/** 
+/**
  * @package UpdateAPI
  * @author  Vontainment <services@vontainment.com>
  * @license https://opensource.org/licenses/MIT MIT License
  * @link    https://vontainment.com
  *
  * Schedule daily theme update checks. */
-function vontmnt_theme_updater_schedule_updates(): void
-{
-    if (! wp_next_scheduled('vontmnt_theme_updater_check_updates')) {
-        wp_schedule_event(time(), 'daily', 'vontmnt_theme_updater_check_updates');
-    }
+function vontmnt_theme_updater_schedule_updates(): void {
+	if ( ! wp_next_scheduled( 'vontmnt_theme_updater_check_updates' ) ) {
+		wp_schedule_event( time(), 'daily', 'vontmnt_theme_updater_check_updates' );
+	}
 }
 
-add_action('wp', 'vontmnt_theme_updater_schedule_updates');
+add_action( 'wp', 'vontmnt_theme_updater_schedule_updates' );
 
-add_action('vontmnt_theme_updater_check_updates', 'vontmnt_theme_updater_run_updates');
+add_action( 'vontmnt_theme_updater_check_updates', 'vontmnt_theme_updater_run_updates' );
 
-/** 
+/**
  * @package UpdateAPI
  * @author  Vontainment <services@vontainment.com>
  * @license https://opensource.org/licenses/MIT MIT License
  * @link    https://vontainment.com
  *
  * Run theme updates for all installed themes. */
-function vontmnt_theme_updater_run_updates(): void
-{
-    if (! function_exists('wp_get_themes')) {
-        require_once ABSPATH . 'wp-includes/theme.php';
-    }
-    $themes = wp_get_themes();
-    foreach ($themes as $theme) {
-        $theme_slug        = $theme->get_stylesheet();
-        $installed_version = $theme->get('Version');
-        $api_url = add_query_arg(
-            array(
-             'type'    => 'theme',
-             'domain'  => rawurlencode(wp_parse_url(site_url(), PHP_URL_HOST)),
-             'slug'    => rawurlencode($theme_slug),
-             'version' => rawurlencode($installed_version),
-             'key'     => VONTMENT_KEY,
-            ),
-            VONTMENT_THEMES
-        );
+function vontmnt_theme_updater_run_updates(): void {
+	if ( ! function_exists( 'wp_get_themes' ) ) {
+		require_once ABSPATH . 'wp-includes/theme.php';
+	}
+	$themes = wp_get_themes();
+	foreach ( $themes as $theme ) {
+		$theme_slug        = $theme->get_stylesheet();
+		$installed_version = $theme->get( 'Version' );
+		$api_url           = add_query_arg(
+			array(
+				'type'    => 'theme',
+				'domain'  => rawurlencode( wp_parse_url( site_url(), PHP_URL_HOST ) ),
+				'slug'    => rawurlencode( $theme_slug ),
+				'version' => rawurlencode( $installed_version ),
+				'key'     => VONTMENT_KEY,
+			),
+			VONTMENT_THEMES
+		);
 
-        $response      = wp_remote_get($api_url);
-        $http_code     = wp_remote_retrieve_response_code($response);
-        $response_body = wp_remote_retrieve_body($response);
+		$response      = wp_remote_get( $api_url );
+		$http_code     = wp_remote_retrieve_response_code( $response );
+		$response_body = wp_remote_retrieve_body( $response );
 
-        if ($http_code === 200 && ! empty($response_body)) {
-            require_once ABSPATH . 'wp-admin/includes/file.php';
-            $upload_dir      = wp_upload_dir();
-            $theme_zip_file = $upload_dir['path'] . '/' . basename($theme_slug) . '.zip';
-            file_put_contents($theme_zip_file, $response_body);
+		if ( $http_code === 200 && ! empty( $response_body ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+			$upload_dir     = wp_upload_dir();
+			$theme_zip_file = $upload_dir['path'] . '/' . basename( $theme_slug ) . '.zip';
+			file_put_contents( $theme_zip_file, $response_body );
 
-            global $wp_filesystem;
-            if (empty($wp_filesystem)) {
-                require_once ABSPATH . '/wp-admin/includes/file.php';
-                WP_Filesystem();
-            }
+			global $wp_filesystem;
+			if ( empty( $wp_filesystem ) ) {
+				require_once ABSPATH . '/wp-admin/includes/file.php';
+				WP_Filesystem();
+			}
 
-            require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
-            $upgrader = new Theme_Upgrader();
-            $callback = function ($options) use ($theme_zip_file) {
-                $options['package']           = $theme_zip_file;
-                $options['clear_destination'] = true;
-                return $options;
-            };
-            add_filter('upgrader_package_options', $callback);
-            $upgrader->install($theme_zip_file);
-            remove_filter('upgrader_package_options', $callback);
+			require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+			$upgrader = new Theme_Upgrader();
+			$callback = function ( $options ) use ( $theme_zip_file ) {
+				$options['package']           = $theme_zip_file;
+				$options['clear_destination'] = true;
+				return $options;
+			};
+			add_filter( 'upgrader_package_options', $callback );
+			$upgrader->install( $theme_zip_file );
+			remove_filter( 'upgrader_package_options', $callback );
 
-            // Delete the theme zip file using wp_delete_file.
-            wp_delete_file($theme_zip_file);
-        } elseif ($http_code === 204) {
-            // No updates, check next theme.
-            continue;
-        } else {
-            // For 400, 403, or any other unexpected code, stop further processing.
-            break;
-        }
-    }
+			// Delete the theme zip file using wp_delete_file.
+			wp_delete_file( $theme_zip_file );
+		} elseif ( $http_code === 204 ) {
+			// No updates, check next theme.
+			continue;
+		} else {
+			// For 400, 403, or any other unexpected code, stop further processing.
+			break;
+		}
+	}
 }

--- a/tests/UtilityTest.php
+++ b/tests/UtilityTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use App\Core\Utility;
+
+if (!defined('DATABASE_FILE')) {
+    define('DATABASE_FILE', __DIR__ . '/blacklist_test.sqlite');
+}
+
+require_once __DIR__ . '/../update-api/app/Core/Utility.php';
+
+final class UtilityTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (file_exists(DATABASE_FILE)) {
+            unlink(DATABASE_FILE);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists(DATABASE_FILE)) {
+            unlink(DATABASE_FILE);
+        }
+    }
+
+    public function testIpGetsBlacklistedAfterThreeFailedAttempts(): void
+    {
+        $ip = '127.0.0.1';
+        Utility::updateFailedAttempts($ip);
+        Utility::updateFailedAttempts($ip);
+        Utility::updateFailedAttempts($ip);
+        $this->assertTrue(Utility::isBlacklisted($ip));
+    }
+
+    public function testBlacklistExpiresAfterThreeDays(): void
+    {
+        $ip = '8.8.8.8';
+        for ($i = 0; $i < 3; $i++) {
+            Utility::updateFailedAttempts($ip);
+        }
+
+        $pdo = new \PDO('sqlite:' . DATABASE_FILE);
+        $pdo->prepare('UPDATE blacklist SET timestamp = :ts WHERE ip = :ip')
+            ->execute([
+                ':ts' => time() - (4 * 24 * 60 * 60),
+                ':ip' => $ip,
+            ]);
+
+        $this->assertFalse(Utility::isBlacklisted($ip));
+
+        $stmt = $pdo->prepare('SELECT blacklisted, login_attempts FROM blacklist WHERE ip = :ip');
+        $stmt->execute([':ip' => $ip]);
+        $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+        $this->assertEquals(0, (int) $row['blacklisted']);
+        $this->assertEquals(0, (int) $row['login_attempts']);
+    }
+}

--- a/update-api/config.php
+++ b/update-api/config.php
@@ -20,5 +20,5 @@ define('BASE_DIR', dirname($_SERVER['DOCUMENT_ROOT']));
 define('HOSTS_ACL', BASE_DIR);
 define('PLUGINS_DIR', BASE_DIR . '/storage/plugins');
 define('THEMES_DIR', BASE_DIR . '/storage/themes');
-define('BLACKLIST_DIR', BASE_DIR . '/storage');
+define('DATABASE_FILE', BASE_DIR . '/storage/database.sqlite');
 define('LOG_DIR', BASE_DIR . '/storage/logs');

--- a/update-api/public/assets/js/header-scripts.js
+++ b/update-api/public/assets/js/header-scripts.js
@@ -6,7 +6,8 @@
  *
  * Displays a toast message.
  * @param {string} message - The message to display. */
-function showToast(message) {
+function showToast(message)
+{
     const toast = document.createElement("div");
     toast.className = "toast";
     toast.textContent = message;


### PR DESCRIPTION
## Summary
- move blacklist storage to a SQLite `blacklist` table
- add PDO helper and database constant
- cover blacklist behaviour with unit tests

## Testing
- `php vendor/bin/phpcs -p update-api/config.php tests/UtilityTest.php`
- `php vendor/bin/phpcs -p update-api/app/Core/Utility.php`
- `php -d error_reporting=E_ALL\&~E_DEPRECATED\&~E_USER_DEPRECATED vendor/bin/phpstan analyse update-api/app/Core/Utility.php tests/UtilityTest.php --level=max`
- `php -d error_reporting=E_ALL\&~E_DEPRECATED\&~E_USER_DEPRECATED phpunit.phar tests/UtilityTest.php`


------
https://chatgpt.com/codex/tasks/task_e_689d85e7f5a4832a81ffd67ac9c6e70b