### PR TITLE
feat: use sqlite for blacklist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Ignore files and directories that should not be tracked by Git
 .vscode/
+update-api/storage/BLACKLIST.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,5 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 - Restricted table generation helpers in controllers and `SessionManager::isValid` to internal use and updated tests accordingly.
 - Fixed PHPStan reported issues by initializing variables, adding explicit type annotations, and excluding vendor code from analysis.
 - Introduced SQLite persistence using Doctrine DBAL with install and cron scripts, and migrated models and controllers to use the database.
+- Replaced JSON-based blacklist with SQLite table that automatically resets entries after three days.
+- Moved blacklist table creation to installer script.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The v-wordpress-plugin-updater project is designed to streamline the management 
 | 🧪 | **Testing**           | <ul><li>Limited unit tests present, primarily for core classes</li><li>Uses PHPUnit for testing PHP components</li><li>Test coverage appears minimal, mainly functional tests</li></ul> |
 | ⚡️  | **Performance**       | <ul><li>Optimized file checks with caching mechanisms</li><li>Minimized HTTP requests during update checks</li><li>Uses transient caching in WordPress</li></ul> |
 | 🛡️ | **Security**          | <ul><li>Sanitizes and validates external inputs</li><li>Uses nonces for admin actions</li><li>Reads configuration files with restricted permissions</li></ul> |
-| 📦 | **Dependencies**      | <ul><li>PHP standard library</li><li>WordPress core functions</li><li>Configuration files: robots.txt, blacklist.json, php.ini, etc.</li></ul> |
+| 📦 | **Dependencies**      | <ul><li>PHP standard library</li><li>WordPress core functions</li><li>Configuration files: robots.txt, php.ini, etc.</li><li>SQLite database for persistence (e.g., updater.sqlite with blacklist table)</li></ul> |
 
 ---
 
@@ -134,7 +134,7 @@ The v-wordpress-plugin-updater project is designed to streamline the management 
     │   │   ├── index.php
     │   │   └── robots.txt
     │   └── storage
-    │       ├── BLACKLIST.json
+    │       ├── updater.sqlite
     │       └── logs
     │           ├── php_app.log
     │           ├── plugin.log
@@ -430,8 +430,8 @@ The v-wordpress-plugin-updater project is designed to streamline the management 
 						</tr>
 					</thead>
 						<tr style='border-bottom: 1px solid #eee;'>
-							<td style='padding: 8px;'><b><a href='https://github.com/djav1985/v-wordpress-plugin-updater/blob/master/update-api/storage/BLACKLIST.json'>BLACKLIST.json</a></b></td>
-							<td style='padding: 8px;'>- Maintains a list of blacklisted entries to enforce security and access control within the update API<br>- Serves as a centralized reference for filtering or blocking specific data, ensuring compliance with security policies across the system<br>- Integrates seamlessly into the overall architecture to support consistent and efficient management of restricted entities.</td>
+                                                        <td style='padding: 8px;'><b>updater.sqlite</b></td>
+                                                        <td style='padding: 8px;'>- SQLite database storing plugin and theme metadata and tracking failed logins in the blacklist table.</td>
 						</tr>
 					</table>
 				</blockquote>
@@ -502,7 +502,7 @@ The v-wordpress-plugin-updater project is designed to streamline the management 
    ```
 6. Ensure the web server user owns the `/storage` directory so uploads and logs can be written.
 
-7. From the `update-api/` directory run `php install.php` to create the SQLite database. Ensure `storage/updater.sqlite` is writable by the web server.
+7. From the `update-api/` directory run `php install.php` to create the SQLite database and required tables, including the blacklist. Ensure `storage/updater.sqlite` is writable by the web server.
 
 8. Configure a system cron to run `php cron.php` regularly so the database stays in sync with the plugin and theme directories.
 

--- a/update-api/app/Models/Blacklist.php
+++ b/update-api/app/Models/Blacklist.php
@@ -14,8 +14,18 @@
 
 namespace App\Models;
 
+use App\Core\DatabaseManager;
+
 class Blacklist
 {
+    /**
+     * Get database connection.
+     */
+    private static function getConnection(): \Doctrine\DBAL\Connection
+    {
+        return DatabaseManager::getConnection();
+    }
+
     /**
      * Update the number of failed login attempts for an IP address and blacklist if necessary.
      *
@@ -24,42 +34,31 @@ class Blacklist
      */
     public static function updateFailedAttempts(string $ip): void
     {
-        $blacklist_file = BLACKLIST_DIR . "/BLACKLIST.json";
-        $content = [];
-        if (file_exists($blacklist_file)) {
-            $raw = @file_get_contents($blacklist_file);
-            if ($raw !== false) {
-                $json = json_decode($raw, true);
-                if (is_array($json)) {
-                    $content = $json;
-                }
-            }
-        }
+        $conn = self::getConnection();
+        $record = $conn->fetchAssociative('SELECT * FROM blacklist WHERE ip = ?', [$ip]);
 
-        if (isset($content[$ip])) {
-            $content[$ip]['login_attempts'] += 1;
-            if ($content[$ip]['login_attempts'] >= 3) {
-                $content[$ip]['blacklisted'] = true;
-                $content[$ip]['timestamp'] = time();
+        if ($record) {
+            $loginAttempts = (int) $record['login_attempts'] + 1;
+            $blacklisted = (int) $record['blacklisted'];
+            $timestamp = (int) $record['timestamp'];
+
+            if ($loginAttempts >= 3) {
+                $blacklisted = 1;
+                $timestamp = time();
             }
+
+            $conn->update('blacklist', [
+                'login_attempts' => $loginAttempts,
+                'blacklisted'   => $blacklisted,
+                'timestamp'     => $timestamp,
+            ], ['ip' => $ip]);
         } else {
-            $content[$ip] = [
-                             'login_attempts' => 1,
-                             'blacklisted'    => false,
-                             'timestamp'      => time(),
-                            ];
-        }
-
-        $fp = fopen($blacklist_file, 'c+');
-        if ($fp) {
-            if (flock($fp, LOCK_EX)) {
-                ftruncate($fp, 0);
-                rewind($fp);
-                fwrite($fp, json_encode($content));
-                fflush($fp);
-                flock($fp, LOCK_UN);
-            }
-            fclose($fp);
+            $conn->insert('blacklist', [
+                'ip'             => $ip,
+                'login_attempts' => 1,
+                'blacklisted'    => 0,
+                'timestamp'      => time(),
+            ]);
         }
     }
 
@@ -71,39 +70,21 @@ class Blacklist
      */
     public static function isBlacklisted(string $ip): bool
     {
-        $blacklist_file = BLACKLIST_DIR . "/BLACKLIST.json";
-        $blacklist = [];
-        if (file_exists($blacklist_file)) {
-            $raw = @file_get_contents($blacklist_file);
-            if ($raw !== false) {
-                $json = json_decode($raw, true);
-                if (is_array($json)) {
-                    $blacklist = $json;
-                }
-            }
-        }
+        $conn = self::getConnection();
+        $record = $conn->fetchAssociative('SELECT * FROM blacklist WHERE ip = ?', [$ip]);
 
-        if (isset($blacklist[$ip]) && $blacklist[$ip]['blacklisted']) {
-            // Check if the timestamp is older than three days
-            if (time() - $blacklist[$ip]['timestamp'] > (3 * 24 * 60 * 60)) {
-                // Remove the IP address from the blacklist and reset login_attempts
-                $blacklist[$ip]['blacklisted'] = false;
-                $blacklist[$ip]['login_attempts'] = 0;
-                $fp = fopen($blacklist_file, 'c+');
-                if ($fp) {
-                    if (flock($fp, LOCK_EX)) {
-                        ftruncate($fp, 0);
-                        rewind($fp);
-                        fwrite($fp, json_encode($blacklist));
-                        fflush($fp);
-                        flock($fp, LOCK_UN);
-                    }
-                    fclose($fp);
-                }
-            } else {
-                return true;
+        if ($record && (int) $record['blacklisted'] === 1) {
+            if (time() - (int) $record['timestamp'] > 3 * 24 * 60 * 60) {
+                $conn->update('blacklist', [
+                    'blacklisted'   => 0,
+                    'login_attempts' => 0,
+                    'timestamp'     => time(),
+                ], ['ip' => $ip]);
+                return false;
             }
+            return true;
         }
         return false;
     }
 }
+

--- a/update-api/config.php
+++ b/update-api/config.php
@@ -22,6 +22,5 @@ define('BASE_DIR', dirname($_SERVER['DOCUMENT_ROOT']));
 define('HOSTS_ACL', BASE_DIR);
 define('PLUGINS_DIR', BASE_DIR . '/storage/plugins');
 define('THEMES_DIR', BASE_DIR . '/storage/themes');
-define('BLACKLIST_DIR', BASE_DIR . '/storage');
 define('LOG_DIR', BASE_DIR . '/storage/logs');
 define('DB_FILE', BASE_DIR . '/storage/updater.sqlite');

--- a/update-api/install.php
+++ b/update-api/install.php
@@ -35,6 +35,13 @@ $logs->addColumn('type', 'text');
 $logs->addColumn('date', 'text');
 $logs->addColumn('status', 'text');
 
+$blacklist = $schema->createTable('blacklist');
+$blacklist->addColumn('ip', 'text');
+$blacklist->addColumn('login_attempts', 'integer');
+$blacklist->addColumn('blacklisted', 'integer');
+$blacklist->addColumn('timestamp', 'integer');
+$blacklist->setPrimaryKey(['ip']);
+
 foreach ($schema->toSql($conn->getDatabasePlatform()) as $sql) {
     $conn->executeStatement($sql);
 }


### PR DESCRIPTION
## Summary
- persist blacklist in SQLite instead of JSON
- adjust session manager tests for database-backed blacklist
- document new SQLite blacklist table and remove JSON file
- create blacklist table during install instead of on demand

## Testing
- `php vendor/bin/phpcs -p update-api/app/Models/Blacklist.php update-api/install.php`
- `vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_689d8c75ed78832aa264415e918b1dd1