### PR TITLE
fix: improve updater request handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,6 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 - Introduced SQLite persistence using Doctrine DBAL with install and cron scripts, and migrated models and controllers to use the database.
 - Replaced JSON-based blacklist with SQLite table that automatically resets entries after three days.
 - Moved blacklist table creation to installer script.
+- Removed `rawurlencode` from updater request parameters to prevent double encoding.
+- Added `WP_Error` checks after `wp_remote_get` calls to log network failures and skip processing.
+- Corrected the header in `v-sys-theme-updater.php` so it loads as a plugin.

--- a/mu-plugin/v-sys-plugin-updater-mu.php
+++ b/mu-plugin/v-sys-plugin-updater-mu.php
@@ -63,21 +63,25 @@ function vontmnt_plugin_updater_run_updates(): void {
 	foreach ( $plugins as $plugin_path => $plugin ) {
 			$plugin_slug       = dirname( $plugin_path );
 			$installed_version = $plugin['Version'];
-			$api_url           = add_query_arg(
-				array(
-					'type'    => 'plugin',
-					'domain'  => rawurlencode( wp_parse_url( site_url(), PHP_URL_HOST ) ),
-					'slug'    => rawurlencode( $plugin_slug ),
-					'version' => rawurlencode( $installed_version ),
-					'key'     => VONTMENT_KEY,
-				),
-				VONTMENT_PLUGINS
-			);
+                        $api_url           = add_query_arg(
+                                array(
+                                        'type'    => 'plugin',
+                                        'domain'  => wp_parse_url( site_url(), PHP_URL_HOST ),
+                                        'slug'    => $plugin_slug,
+                                        'version' => $installed_version,
+                                        'key'     => VONTMENT_KEY,
+                                ),
+                                VONTMENT_PLUGINS
+                        );
 
-			// Use wp_remote_get instead of cURL.
-			$response      = wp_remote_get( $api_url );
-			$http_code     = wp_remote_retrieve_response_code( $response );
-			$response_body = wp_remote_retrieve_body( $response );
+                        // Use wp_remote_get instead of cURL.
+                        $response = wp_remote_get( $api_url );
+                        if ( is_wp_error( $response ) ) {
+                                error_log( 'Plugin updater error: ' . $response->get_error_message() );
+                                continue;
+                        }
+                        $http_code     = wp_remote_retrieve_response_code( $response );
+                        $response_body = wp_remote_retrieve_body( $response );
 
 		if ( 200 === $http_code && ! empty( $response_body ) ) {
 			require_once ABSPATH . 'wp-admin/includes/file.php';

--- a/mu-plugin/v-sys-plugin-updater.php
+++ b/mu-plugin/v-sys-plugin-updater.php
@@ -54,21 +54,25 @@ function vontmnt_plugin_updater_run_updates(): void {
 	foreach ( $plugins as $plugin_path => $plugin ) {
 		$plugin_slug       = dirname( $plugin_path );
 		$installed_version = $plugin['Version'];
-		$api_url           = add_query_arg(
-			array(
-				'type'    => 'plugin',
-				'domain'  => rawurlencode( wp_parse_url( site_url(), PHP_URL_HOST ) ),
-				'slug'    => rawurlencode( $plugin_slug ),
-				'version' => rawurlencode( $installed_version ),
-				'key'     => VONTMENT_KEY,
-			),
-			VONTMENT_PLUGINS
-		);
+                $api_url           = add_query_arg(
+                        array(
+                                'type'    => 'plugin',
+                                'domain'  => wp_parse_url( site_url(), PHP_URL_HOST ),
+                                'slug'    => $plugin_slug,
+                                'version' => $installed_version,
+                                'key'     => VONTMENT_KEY,
+                        ),
+                        VONTMENT_PLUGINS
+                );
 
-		// Use wp_remote_get instead of cURL.
-		$response      = wp_remote_get( $api_url );
-		$http_code     = wp_remote_retrieve_response_code( $response );
-		$response_body = wp_remote_retrieve_body( $response );
+                // Use wp_remote_get instead of cURL.
+                $response = wp_remote_get( $api_url );
+                if ( is_wp_error( $response ) ) {
+                        error_log( 'Plugin updater error: ' . $response->get_error_message() );
+                        continue;
+                }
+                $http_code     = wp_remote_retrieve_response_code( $response );
+                $response_body = wp_remote_retrieve_body( $response );
 
 		if ( $http_code === 200 && ! empty( $response_body ) ) {
 			require_once ABSPATH . 'wp-admin/includes/file.php';

--- a/mu-plugin/v-sys-theme-updater-mu.php
+++ b/mu-plugin/v-sys-theme-updater-mu.php
@@ -63,20 +63,24 @@ function vontmnt_theme_updater_run_updates(): void {
 	foreach ( $themes as $theme ) {
 		$theme_slug        = $theme->get_stylesheet();
 		$installed_version = $theme->get( 'Version' );
-		$api_url           = add_query_arg(
-			array(
-				'type'    => 'theme',
-				'domain'  => rawurlencode( wp_parse_url( site_url(), PHP_URL_HOST ) ),
-				'slug'    => rawurlencode( $theme_slug ),
-				'version' => rawurlencode( $installed_version ),
-				'key'     => VONTMENT_KEY,
-			),
-			VONTMENT_THEMES
-		);
+                $api_url           = add_query_arg(
+                        array(
+                                'type'    => 'theme',
+                                'domain'  => wp_parse_url( site_url(), PHP_URL_HOST ),
+                                'slug'    => $theme_slug,
+                                'version' => $installed_version,
+                                'key'     => VONTMENT_KEY,
+                        ),
+                        VONTMENT_THEMES
+                );
 
-		$response      = wp_remote_get( $api_url );
-		$http_code     = wp_remote_retrieve_response_code( $response );
-		$response_body = wp_remote_retrieve_body( $response );
+                $response = wp_remote_get( $api_url );
+                if ( is_wp_error( $response ) ) {
+                        error_log( 'Theme updater error: ' . $response->get_error_message() );
+                        continue;
+                }
+                $http_code     = wp_remote_retrieve_response_code( $response );
+                $response_body = wp_remote_retrieve_body( $response );
 
 		if ( $http_code === 200 && ! empty( $response_body ) ) {
 			require_once ABSPATH . 'wp-admin/includes/file.php';

--- a/mu-plugin/v-sys-theme-updater.php
+++ b/mu-plugin/v-sys-theme-updater.php
@@ -9,9 +9,9 @@
  * File: v-sys-theme-updater.php
  * Description: WordPress Update API
  *
- * Theme Name: WP Theme Updater
- * Theme URI: https://vontainment.com
- * Description: This theme updates your WordPress themes.
+ * Plugin Name: WP Theme Updater
+ * Plugin URI: https://vontainment.com
+ * Description: This plugin updates your WordPress themes.
  * Version: 1.2.0
  * Author: Vontainment
  * Author URI: https://vontainment.com
@@ -55,20 +55,24 @@ function vontmnt_theme_updater_run_updates(): void {
 	foreach ( $themes as $theme ) {
 		$theme_slug        = $theme->get_stylesheet();
 		$installed_version = $theme->get( 'Version' );
-		$api_url           = add_query_arg(
-			array(
-				'type'    => 'theme',
-				'domain'  => rawurlencode( wp_parse_url( site_url(), PHP_URL_HOST ) ),
-				'slug'    => rawurlencode( $theme_slug ),
-				'version' => rawurlencode( $installed_version ),
-				'key'     => VONTMENT_KEY,
-			),
-			VONTMENT_THEMES
-		);
+                $api_url           = add_query_arg(
+                        array(
+                                'type'    => 'theme',
+                                'domain'  => wp_parse_url( site_url(), PHP_URL_HOST ),
+                                'slug'    => $theme_slug,
+                                'version' => $installed_version,
+                                'key'     => VONTMENT_KEY,
+                        ),
+                        VONTMENT_THEMES
+                );
 
-		$response      = wp_remote_get( $api_url );
-		$http_code     = wp_remote_retrieve_response_code( $response );
-		$response_body = wp_remote_retrieve_body( $response );
+                $response = wp_remote_get( $api_url );
+                if ( is_wp_error( $response ) ) {
+                        error_log( 'Theme updater error: ' . $response->get_error_message() );
+                        continue;
+                }
+                $http_code     = wp_remote_retrieve_response_code( $response );
+                $response_body = wp_remote_retrieve_body( $response );
 
 		if ( $http_code === 200 && ! empty( $response_body ) ) {
 			require_once ABSPATH . 'wp-admin/includes/file.php';

--- a/tests/UpdaterEncodingTest.php
+++ b/tests/UpdaterEncodingTest.php
@@ -1,0 +1,37 @@
+<?php
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+
+if (!function_exists(__NAMESPACE__ . '\\add_query_arg')) {
+    function add_query_arg($args, $url)
+    {
+        return $url . '?' . http_build_query($args, '', '&', PHP_QUERY_RFC3986);
+    }
+}
+
+class UpdaterEncodingTest extends TestCase
+{
+    public function testAddQueryArgEncodesOnce(): void
+    {
+        $args = [
+            'type'    => 'plugin',
+            'domain'  => 'example.com',
+            'slug'    => 'my plugin',
+            'version' => '1.0.0',
+            'key'     => 'abc',
+        ];
+
+        $url = add_query_arg($args, 'https://api.example.com');
+
+        $this->assertStringContainsString('slug=my%20plugin', $url);
+        $this->assertStringNotContainsString('my%2520plugin', $url);
+    }
+
+    public function testThemeUpdaterHasPluginHeader(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../mu-plugin/v-sys-theme-updater.php');
+        $this->assertStringContainsString('Plugin Name:', $content);
+        $this->assertStringNotContainsString('Theme Name:', $content);
+    }
+}

--- a/tests/UpdaterErrorHandlingTest.php
+++ b/tests/UpdaterErrorHandlingTest.php
@@ -1,0 +1,80 @@
+<?php
+namespace {
+    class WP_Error {
+        private string $message;
+        public function __construct(string $code, string $message) {
+            $this->message = $message;
+        }
+        public function get_error_message(): string {
+            return $this->message;
+        }
+    }
+    function add_action(...$args) {}
+    function wp_next_scheduled($hook) { return false; }
+    function wp_schedule_event($timestamp, $recurrence, $hook) {}
+    function get_plugins() { return ['my-plugin/my-plugin.php' => ['Version' => '1.0.0']]; }
+    function wp_parse_url($url, $component) { return 'example.com'; }
+    function site_url() { return 'https://example.com'; }
+    function add_query_arg($args, $url) { return $url . '?' . http_build_query($args, '', '&', PHP_QUERY_RFC3986); }
+    function wp_remote_get($url) { return new WP_Error('error', 'network error'); }
+    function wp_get_themes() { return [ new class { public function get_stylesheet() { return 'my-theme'; } public function get($field) { return '1.0.0'; } } ]; }
+    function wp_upload_dir() { return ['path' => sys_get_temp_dir()]; }
+    function wp_delete_file($file) {}
+    function add_filter(...$args) {}
+    function remove_filter(...$args) {}
+    function is_main_site() { return true; }
+    function is_wp_error($thing) { return $thing instanceof WP_Error; }
+}
+
+namespace Tests {
+
+use PHPUnit\Framework\TestCase;
+
+class UpdaterErrorHandlingTest extends TestCase
+{
+    private string $logFile;
+
+    protected function setUp(): void
+    {
+        $this->logFile = tempnam(sys_get_temp_dir(), 'log');
+        ini_set('error_log', $this->logFile);
+        if (!defined('ABSPATH')) {
+            define('ABSPATH', __DIR__ . '/../');
+        }
+        if (!defined('VONTMENT_KEY')) {
+            define('VONTMENT_KEY', 'key');
+        }
+        if (!defined('VONTMENT_PLUGINS')) {
+            define('VONTMENT_PLUGINS', 'https://example.com/plugins');
+        }
+        if (!defined('VONTMENT_THEMES')) {
+            define('VONTMENT_THEMES', 'https://example.com/themes');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->logFile)) {
+            unlink($this->logFile);
+        }
+    }
+
+    public function testPluginUpdaterHandlesWpError(): void
+    {
+        require_once __DIR__ . '/../mu-plugin/v-sys-plugin-updater.php';
+        vontmnt_plugin_updater_run_updates();
+        $log = file_get_contents($this->logFile);
+        $this->assertStringContainsString('Plugin updater error: network error', $log);
+    }
+
+    public function testThemeUpdaterHandlesWpError(): void
+    {
+        require_once __DIR__ . '/../mu-plugin/v-sys-theme-updater.php';
+        vontmnt_theme_updater_run_updates();
+        $log = file_get_contents($this->logFile);
+        $this->assertStringContainsString('Theme updater error: network error', $log);
+    }
+}
+
+
+}


### PR DESCRIPTION
## Summary
- remove redundant rawurlencode calls when building update API queries
- add WP_Error checks and logging around wp_remote_get requests
- update theme updater header and add tests for encoding, error handling, and plugin loading

## Testing
- `php -l mu-plugin/v-sys-plugin-updater.php`
- `php -l mu-plugin/v-sys-plugin-updater-mu.php`
- `php -l mu-plugin/v-sys-theme-updater.php`
- `php -l mu-plugin/v-sys-theme-updater-mu.php`
- `vendor/bin/phpunit --no-configuration tests/UpdaterEncodingTest.php`
- `vendor/bin/phpunit --no-configuration tests/UpdaterErrorHandlingTest.php`
- `vendor/bin/phpunit --no-configuration tests`


------
https://chatgpt.com/codex/tasks/task_e_689daa0f7ab8832a9830456c3823c230